### PR TITLE
Align JVM targets and fix Compose build issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,13 @@ android {
         versionName "1.0"
     }
     buildFeatures { compose true }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.10'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
     kotlinOptions { jvmTarget = '17' }
     buildTypes {
         release {
@@ -26,6 +33,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.activity:activity-compose:1.9.0'
     implementation 'androidx.compose.material3:material3:1.2.1'
+    implementation "androidx.compose.material:material-icons-extended:1.6.7"
     implementation 'androidx.navigation:navigation-compose:2.8.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0'
 }

--- a/app/src/main/java/com/example/myandroidapp/components/VisualBlockBuilder.kt
+++ b/app/src/main/java/com/example/myandroidapp/components/VisualBlockBuilder.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.myandroidapp.shared.AutomationFilter

--- a/app/src/main/java/com/example/myandroidapp/screens/RootNavigation.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/RootNavigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.padding
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.*


### PR DESCRIPTION
## Summary
- match Java and Kotlin JVM targets at 17 and enable Compose compiler 1.5.10
- add Material icons dependency and missing imports for Compose APIs
- update visual builder component to use SnapshotStateList and Alignment

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b680f6ba808321af1a7ebc978e3119