### PR TITLE
Add placeholder navigation sections and split chart-trade view

### DIFF
--- a/app/src/main/java/com/example/myandroidapp/components/ChartTradeSplit.kt
+++ b/app/src/main/java/com/example/myandroidapp/components/ChartTradeSplit.kt
@@ -1,0 +1,52 @@
+package com.example.myandroidapp.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.myandroidapp.shared.SharedAppViewModel
+
+@Composable
+fun ChartTradeSplit(viewModel: SharedAppViewModel) {
+    var split by remember { mutableStateOf(false) }
+    var ratio by remember { mutableStateOf(0.5f) }
+    Column(Modifier.fillMaxSize()) {
+        Row(
+            Modifier.fillMaxWidth().padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(viewModel.selectedTicker.value ?: "Select a Coin")
+            TextButton(onClick = { split = !split }) {
+                Text(if (split) "Single View" else "Split View")
+            }
+        }
+        if (split) {
+            Slider(value = ratio, onValueChange = { ratio = it })
+            Row(Modifier.fillMaxSize()) {
+                PlaceholderChart(Modifier.weight(ratio))
+                TradeForm(viewModel, Modifier.weight(1 - ratio))
+            }
+        } else {
+            PlaceholderChart(Modifier.fillMaxSize())
+        }
+    }
+}
+
+@Composable
+fun TradeForm(viewModel: SharedAppViewModel, modifier: Modifier = Modifier) {
+    var mode by remember { mutableStateOf(0) }
+    Column(modifier.fillMaxSize().padding(16.dp)) {
+        TabRow(selectedTabIndex = mode) {
+            Tab(selected = mode == 0, onClick = { mode = 0 }, text = { Text("Buy") })
+            Tab(selected = mode == 1, onClick = { mode = 1 }, text = { Text("Sell") })
+        }
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(value = "", onValueChange = {}, label = { Text("Amount") }, modifier = Modifier.fillMaxWidth())
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = { }, modifier = Modifier.fillMaxWidth()) {
+            val action = if (mode == 0) "Buy" else "Sell"
+            Text("$action ${viewModel.selectedTicker.value ?: ""}")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myandroidapp/screens/HomeSection.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/HomeSection.kt
@@ -1,0 +1,100 @@
+package com.example.myandroidapp.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.myandroidapp.components.PlaceholderChart
+import com.example.myandroidapp.components.PlaceholderTable
+import com.example.myandroidapp.shared.SharedAppViewModel
+
+private val homeTabs = listOf("Overview", "Portfolio", "My Stuff")
+
+@Composable
+fun HomeSection(viewModel: SharedAppViewModel) {
+    val nav = rememberNavController()
+    NavHost(navController = nav, startDestination = "Portfolio") {
+        composable("Overview") { HomeOverview(nav, viewModel) }
+        composable("Portfolio") { HomePortfolio(nav) }
+        composable("My Stuff") { HomeMyStuff(nav, viewModel) }
+    }
+}
+
+@Composable
+fun HomeTopTabs(nav: NavController, current: String) {
+    TabRow(selectedTabIndex = homeTabs.indexOf(current)) {
+        homeTabs.forEach { tab ->
+            Tab(
+                selected = current == tab,
+                onClick = { nav.navigate(tab) },
+                text = { Text(tab) }
+            )
+        }
+    }
+}
+
+@Composable
+fun HomeOverview(nav: NavController, viewModel: SharedAppViewModel) {
+    Column(Modifier.fillMaxSize()) {
+        HomeTopTabs(nav, "Overview")
+        LazyColumn(Modifier.fillMaxSize()) {
+            item { Text("Overview content (market stats, charts, trending)", modifier = Modifier.padding(16.dp)) }
+            item { PlaceholderChart() }
+            item { PlaceholderTable() }
+        }
+    }
+}
+
+@Composable
+fun HomePortfolio(nav: NavController) {
+    Column(Modifier.fillMaxSize()) {
+        HomeTopTabs(nav, "Portfolio")
+        LazyColumn(Modifier.fillMaxSize().padding(16.dp)) {
+            item {
+                Card(Modifier.fillMaxWidth()) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text("$47,832.42", style = MaterialTheme.typography.headlineSmall)
+                        Text("+6.32%", color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+            }
+            item { Spacer(Modifier.height(16.dp)) }
+            items(listOf("BTC" to "Bitcoin", "ETH" to "Ethereum", "USDC" to "USD Coin")) { (sym, name) ->
+                Card(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                    Row(Modifier.padding(16.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+                        Column { Text(name); Text(sym, style = MaterialTheme.typography.bodySmall) }
+                        Column { Text("0.0", style = MaterialTheme.typography.bodyMedium); Text("$0.00", style = MaterialTheme.typography.bodySmall) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HomeMyStuff(nav: NavController, viewModel: SharedAppViewModel) {
+    Column(Modifier.fillMaxSize()) {
+        HomeTopTabs(nav, "My Stuff")
+        LazyColumn(Modifier.fillMaxSize().padding(16.dp)) {
+            if (viewModel.savedAutomations.isEmpty()) {
+                item { Text("No saved items") }
+            } else {
+                items(viewModel.savedAutomations) { rule ->
+                    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                        Column(Modifier.padding(16.dp)) {
+                            Text("Saved Rule", style = MaterialTheme.typography.titleSmall)
+                            Text(rule.filters.joinToString { it.metric })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/myandroidapp/screens/MarketSection.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/MarketSection.kt
@@ -1,6 +1,8 @@
 package com.example.myandroidapp.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -8,20 +10,18 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.*
 
-import com.example.myandroidapp.components.PlaceholderChart
-import com.example.myandroidapp.components.PlaceholderTable
 import com.example.myandroidapp.components.ScrollAwareScaffold
+import com.example.myandroidapp.components.ChartTradeSplit
 import com.example.myandroidapp.shared.SharedAppViewModel
 
-private val marketTabs = listOf("Overview", "Index", "Charts", "Trends")
+private val marketTabs = listOf("Index", "Charts", "Trends")
 
 @Composable
 fun MarketSection(viewModel: SharedAppViewModel) {
     val nav = rememberNavController()
-    NavHost(navController = nav, startDestination = "Overview") {
-        composable("Overview") { OverviewTab(nav) }
-        composable("Index") { IndexTab(nav) }
-        composable("Charts") { ChartsTab(nav) }
+    NavHost(navController = nav, startDestination = "Index") {
+        composable("Index") { IndexTab(nav, viewModel) }
+        composable("Charts") { ChartsTab(nav, viewModel) }
         composable("Trends") { TrendsTab(nav) }
     }
 }
@@ -40,26 +40,7 @@ fun TopTabs(nav: NavController, current: String) {
 }
 
 @Composable
-fun OverviewTab(nav: NavController) {
-    ScrollAwareScaffold(
-        searchBarContent = {
-            OutlinedTextField(
-                value = "",
-                onValueChange = {},
-                label = { Text("Search Coins") },
-                modifier = Modifier.fillMaxWidth().padding(16.dp)
-            )
-        },
-        topTabsContent = { TopTabs(nav, "Overview") }
-    ) {
-        item { Text("Charts & Tables (Placeholder)", modifier = Modifier.padding(16.dp)) }
-        item { PlaceholderChart() }
-        item { PlaceholderTable() }
-    }
-}
-
-@Composable
-fun IndexTab(nav: NavController) {
+fun IndexTab(nav: NavController, viewModel: SharedAppViewModel) {
     ScrollAwareScaffold(
         searchBarContent = {
             OutlinedTextField(
@@ -82,12 +63,26 @@ fun IndexTab(nav: NavController) {
                 OutlinedButton(onClick = { /* TODO columns */ }) { Text("Columns") }
             }
         }
-        item { PlaceholderTable(columns = 6, rowHeight = 20.dp) }
+        items(listOf("BTC", "ETH", "BNB", "SOL")) { sym ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        viewModel.selectedTicker.value = sym
+                        nav.navigate("Charts")
+                    }
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(sym)
+                Text("$0.00")
+            }
+        }
     }
 }
 
 @Composable
-fun ChartsTab(nav: NavController) {
+fun ChartsTab(nav: NavController, viewModel: SharedAppViewModel) {
     ScrollAwareScaffold(
         searchBarContent = {
             OutlinedTextField(
@@ -99,7 +94,7 @@ fun ChartsTab(nav: NavController) {
         },
         topTabsContent = { TopTabs(nav, "Charts") }
     ) {
-        item { PlaceholderChart() }
+        item { ChartTradeSplit(viewModel) }
     }
 }
 

--- a/app/src/main/java/com/example/myandroidapp/screens/RootNavigation.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/RootNavigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
@@ -38,17 +39,21 @@ fun RootNavigation() {
         },
         bottomBar = { RootBottomNavBar(navController) }
     ) { padding ->
-        NavHost(navController = navController, startDestination = "market", modifier = Modifier.padding(padding)) {
-            composable("market") { MarketSection(viewModel) }
+        NavHost(navController = navController, startDestination = "home", modifier = Modifier.padding(padding)) {
+            composable("home") { HomeSection(viewModel) }
+            composable("markets") { MarketSection(viewModel) }
             composable("tools") { ToolsSection(viewModel) }
-            composable("profile") { Text("Profile Screen Placeholder") }
         }
     }
 }
 
 @Composable
 fun RootBottomNavBar(navController: NavHostController) {
-    val items = listOf("market" to Icons.Default.BarChart, "tools" to Icons.Default.Build, "profile" to Icons.Default.Person)
+    val items = listOf(
+        "home" to Icons.Default.Home,
+        "markets" to Icons.Default.BarChart,
+        "tools" to Icons.Default.Build
+    )
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 

--- a/app/src/main/java/com/example/myandroidapp/screens/ToolsSection.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/ToolsSection.kt
@@ -1,29 +1,67 @@
 package com.example.myandroidapp.screens
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.myandroidapp.components.ChartTradeSplit
+import com.example.myandroidapp.components.VisualBlockBuilder
+import com.example.myandroidapp.shared.AutomationAction
+import com.example.myandroidapp.shared.AutomationFilter
+import com.example.myandroidapp.shared.AutomationRule
 import com.example.myandroidapp.shared.SharedAppViewModel
+
+private val toolTabs = listOf("Trade", "Automation", "Notifications", "Analysis")
 
 @Composable
 fun ToolsSection(viewModel: SharedAppViewModel) {
     val nav = rememberNavController()
-    NavHost(navController = nav, startDestination = "Automation") {
-        composable("Automation") {
-            AutomationScreen(viewModel)
-        }
-        composable("Trading") {
-            Text("Trading Screen Placeholder")
-        }
-        composable("Notifications") {
-            Text("Notifications Screen Placeholder")
+    NavHost(navController = nav, startDestination = "Trade") {
+        composable("Trade") { TradeTab(nav, viewModel) }
+        composable("Automation") { BlockTab(nav, viewModel, "Automation") }
+        composable("Notifications") { BlockTab(nav, viewModel, "Notifications") }
+        composable("Analysis") { BlockTab(nav, viewModel, "Analysis") }
+    }
+}
+
+@Composable
+fun ToolTopTabs(nav: NavController, current: String) {
+    TabRow(selectedTabIndex = toolTabs.indexOf(current)) {
+        toolTabs.forEach { tab ->
+            Tab(selected = current == tab, onClick = { nav.navigate(tab) }, text = { Text(tab) })
         }
     }
 }
 
 @Composable
-fun AutomationScreen(viewModel: SharedAppViewModel) {
-    Text("Automation Screen Placeholder")
+fun TradeTab(nav: NavController, viewModel: SharedAppViewModel) {
+    Column(Modifier.fillMaxSize()) {
+        ToolTopTabs(nav, "Trade")
+        ChartTradeSplit(viewModel)
+    }
+}
+
+@Composable
+fun BlockTab(nav: NavController, viewModel: SharedAppViewModel, title: String) {
+    val filters = remember { mutableStateListOf<AutomationFilter>() }
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        ToolTopTabs(nav, title)
+        Spacer(Modifier.height(16.dp))
+        VisualBlockBuilder(filters) { filters.add(AutomationFilter("", "", "")) }
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = {
+            viewModel.savedAutomations.add(
+                AutomationRule(filters.toList(), AutomationAction(title, "", "", "", ""), runMode = "once")
+            )
+        }, modifier = Modifier.fillMaxWidth()) {
+            Text("Save to My Stuff")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add Home section with overview, portfolio, and saved items tabs
- Implement Markets section with index list and chart/trade split view
- Build Tools section with trade screen and reusable block-based editors
- Fix MarketSection lazy list import to restore successful builds

## Testing
- `./gradlew build --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68bdef9f08d48321bb7fe2ce72e542d0