### PR TITLE
PR #5 — PaperBroker (deterministic)

### DIFF
--- a/paperbroker/src/main/kotlin/com/kevin/cryptotrader/paperbroker/PaperBroker.kt
+++ b/paperbroker/src/main/kotlin/com/kevin/cryptotrader/paperbroker/PaperBroker.kt
@@ -1,0 +1,83 @@
+package com.kevin.cryptotrader.paperbroker
+
+import com.kevin.cryptotrader.contracts.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+data class PaperBrokerConfig(
+  val ackLatencyMs: Long = 0,
+  val firstFillLatencyMs: Long = 0,
+  val perFillIntervalMs: Long = 0,
+  val slippageBps: Int = 0,
+  val feeBps: Int = 0,
+  val partialPieces: Int = 1,
+  val clockMs: () -> Long = { System.currentTimeMillis() },
+  val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+)
+
+fun interface PriceSource { fun price(symbol: String, ts: Long): Double }
+
+class PaperBroker(
+  private val cfg: PaperBrokerConfig,
+  private val priceSource: PriceSource,
+) : Broker {
+  private val events = MutableSharedFlow<BrokerEvent>(replay = 0, extraBufferCapacity = 64)
+  private val openOrders = ConcurrentHashMap<String, Order>()
+  private val jobs = ConcurrentHashMap<String, Job>()
+
+  override suspend fun place(order: Order): String {
+    val id = if (order.clientOrderId.isNotBlank()) order.clientOrderId else "ord-${cfg.clockMs()}-${openOrders.size}"
+    openOrders[id] = order
+    cfg.scope.launch {
+      if (cfg.ackLatencyMs > 0) delay(cfg.ackLatencyMs)
+      events.emit(BrokerEvent.Accepted(id, order))
+    }.also { jobs[id] = it }
+
+    jobs[id] = cfg.scope.launch {
+      if (cfg.firstFillLatencyMs > 0) delay(cfg.firstFillLatencyMs)
+      val totalQty = order.qty
+      val pieces = cfg.partialPieces.coerceAtLeast(1)
+      val basePiece = totalQty / pieces
+      var remaining = totalQty
+      repeat(pieces) { idx ->
+        if (!openOrders.containsKey(id)) return@launch
+        val ts = cfg.clockMs()
+        val ref = priceSource.price(order.symbol, ts)
+        val slip = cfg.slippageBps / 10_000.0
+        val fillPrice = when (order.side) {
+          Side.BUY -> ref * (1.0 + slip)
+          Side.SELL -> ref * (1.0 - slip)
+        }
+        val qty = if (idx == pieces - 1) remaining else basePiece
+        remaining -= qty
+        val fill = Fill(orderId = id, qty = qty, price = fillPrice, ts = ts)
+        val evt = if (idx == pieces - 1) BrokerEvent.Filled(id, fill) else BrokerEvent.PartialFill(id, fill)
+        events.tryEmit(evt)
+        if (idx != pieces - 1 && cfg.perFillIntervalMs > 0) delay(cfg.perFillIntervalMs)
+      }
+      openOrders.remove(id)
+    }
+    return id
+  }
+
+  override suspend fun cancel(orderId: String): Boolean {
+    val o = openOrders.remove(orderId) ?: return false
+    jobs.remove(orderId)?.cancel()
+    events.emit(BrokerEvent.Canceled(orderId))
+    return true
+  }
+
+  override fun streamEvents(symbols: Set<String>): Flow<BrokerEvent> = events.asSharedFlow()
+
+  override suspend fun account(): AccountSnapshot {
+    return AccountSnapshot(equityUsd = 0.0, balances = emptyMap())
+  }
+}
+

--- a/paperbroker/src/test/kotlin/com/kevin/cryptotrader/paperbroker/PaperBrokerTest.kt
+++ b/paperbroker/src/test/kotlin/com/kevin/cryptotrader/paperbroker/PaperBrokerTest.kt
@@ -1,0 +1,85 @@
+package com.kevin.cryptotrader.paperbroker
+
+import com.kevin.cryptotrader.contracts.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PaperBrokerTest {
+  @Test
+  fun deterministic_single_fill_with_slippage_and_latency() = runTest {
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val scope = TestScope(dispatcher)
+    var now = 0L
+    val cfg = PaperBrokerConfig(
+      ackLatencyMs = 100,
+      firstFillLatencyMs = 200,
+      perFillIntervalMs = 0,
+      slippageBps = 10,
+      partialPieces = 1,
+      clockMs = { now },
+      scope = scope,
+    )
+    val price = PriceSource { _, _ -> 100.0 }
+    val broker = PaperBroker(cfg, price)
+    val events = mutableListOf<BrokerEvent>()
+    val job = scope.launch { broker.streamEvents(emptySet()).toList(events) }
+
+    val id = broker.place(Order(clientOrderId = "", symbol = "BTCUSDT", side = Side.BUY, type = OrderType.MARKET, qty = 1.0))
+
+    // Advance to ack
+    advanceTimeBy(100); now = 100
+    // Advance to fill
+    advanceTimeBy(100); now = 200
+
+    job.cancel()
+
+    // Expect Accepted then Filled with slippage applied
+    assertTrue(events.first() is BrokerEvent.Accepted)
+    val filled = events.filterIsInstance<BrokerEvent.Filled>().first()
+    assertEquals(id, filled.orderId)
+    assertEquals(1.0, filled.fill.qty)
+    assertEquals(100.0 * 1.001, filled.fill.price, 1e-9)
+  }
+
+  @Test
+  fun partial_fills_and_cancel() = runTest {
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val scope = TestScope(dispatcher)
+    var now = 0L
+    val cfg = PaperBrokerConfig(
+      ackLatencyMs = 0,
+      firstFillLatencyMs = 50,
+      perFillIntervalMs = 50,
+      slippageBps = 0,
+      partialPieces = 3,
+      clockMs = { now },
+      scope = scope,
+    )
+    val price = PriceSource { _, _ -> 10.0 }
+    val broker = PaperBroker(cfg, price)
+    val collected = mutableListOf<BrokerEvent>()
+    val job = scope.launch { broker.streamEvents(emptySet()).toList(collected) }
+
+    val id = broker.place(Order(clientOrderId = "", symbol = "ETHUSDT", side = Side.SELL, type = OrderType.MARKET, qty = 3.0))
+    advanceTimeBy(50); now = 50
+    // Cancel before second piece
+    broker.cancel(id)
+    advanceTimeBy(200); now = 250
+    job.cancel()
+
+    // We should have at least one PartialFill and one Canceled, and no final Filled
+    assertTrue(collected.any { it is BrokerEvent.PartialFill })
+    assertTrue(collected.any { it is BrokerEvent.Canceled })
+    assertTrue(collected.none { it is BrokerEvent.Filled })
+  }
+}
+


### PR DESCRIPTION
Implements Track D minimal deterministic PaperBroker:\n\n- Configurable latency, slippage (bps), partial fills (pieces + intervals)\n- Emits BrokerEvent.Accepted/PartialFill/Filled/Canceled with deterministic clock\n- PriceSource injection for deterministic tests\n- Unit tests using kotlinx-coroutines-test (virtual time)\n\nNo workflow changes. CI: ./gradlew ktlintCheck detekt test -x lint