### PR TITLE
Add persistence module with ledger service and parity tests

### DIFF
--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+  kotlin("jvm")
+  kotlin("plugin.serialization")
+}
+
+kotlin { jvmToolchain(17) }
+
+dependencies {
+  implementation(project(":contracts"))
+  implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+  implementation("androidx.room:room-common:2.6.1")
+
+  testImplementation(kotlin("test"))
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+}
+
+tasks.test { useJUnitPlatform() }

--- a/persistence/src/main/kotlin/androidx/room/RoomDatabase.kt
+++ b/persistence/src/main/kotlin/androidx/room/RoomDatabase.kt
@@ -1,0 +1,7 @@
+package androidx.room
+
+/**
+ * Minimal stub of [RoomDatabase] to allow compiling Room annotated components in a pure JVM
+ * environment without the Android runtime.
+ */
+abstract class RoomDatabase

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/TraderDatabase.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/TraderDatabase.kt
@@ -1,0 +1,52 @@
+package com.kevin.cryptotrader.persistence
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.kevin.cryptotrader.persistence.dao.AutomationStateDao
+import com.kevin.cryptotrader.persistence.dao.CandleDao
+import com.kevin.cryptotrader.persistence.dao.FillDao
+import com.kevin.cryptotrader.persistence.dao.IntentDao
+import com.kevin.cryptotrader.persistence.dao.LedgerEventDao
+import com.kevin.cryptotrader.persistence.dao.OrderDao
+import com.kevin.cryptotrader.persistence.dao.PolicyDao
+import com.kevin.cryptotrader.persistence.dao.PositionDao
+import com.kevin.cryptotrader.persistence.entity.AutomationStateEntity
+import com.kevin.cryptotrader.persistence.entity.CandleEntity
+import com.kevin.cryptotrader.persistence.entity.FillEntity
+import com.kevin.cryptotrader.persistence.entity.IntentEntity
+import com.kevin.cryptotrader.persistence.entity.LedgerEventEntity
+import com.kevin.cryptotrader.persistence.entity.OrderEntity
+import com.kevin.cryptotrader.persistence.entity.PolicyEntity
+import com.kevin.cryptotrader.persistence.entity.PositionEntity
+
+@Database(
+  entities = [
+    CandleEntity::class,
+    IntentEntity::class,
+    OrderEntity::class,
+    FillEntity::class,
+    PositionEntity::class,
+    PolicyEntity::class,
+    AutomationStateEntity::class,
+    LedgerEventEntity::class,
+  ],
+  version = 2,
+  exportSchema = false,
+)
+abstract class TraderDatabase : RoomDatabase() {
+  abstract fun candleDao(): CandleDao
+
+  abstract fun intentDao(): IntentDao
+
+  abstract fun orderDao(): OrderDao
+
+  abstract fun fillDao(): FillDao
+
+  abstract fun positionDao(): PositionDao
+
+  abstract fun policyDao(): PolicyDao
+
+  abstract fun automationStateDao(): AutomationStateDao
+
+  abstract fun ledgerEventDao(): LedgerEventDao
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/AutomationStateDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/AutomationStateDao.kt
@@ -1,0 +1,16 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.AutomationStateEntity
+
+@Dao
+interface AutomationStateDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(state: AutomationStateEntity)
+
+  @Query("SELECT * FROM automation_state WHERE automationId = :id")
+  suspend fun findById(id: String): AutomationStateEntity?
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/CandleDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/CandleDao.kt
@@ -1,0 +1,21 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.CandleEntity
+
+@Dao
+interface CandleDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(candle: CandleEntity)
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsertAll(candles: List<CandleEntity>)
+
+  @Query(
+    "SELECT * FROM candles WHERE symbol = :symbol AND interval = :interval ORDER BY ts DESC LIMIT :limit",
+  )
+  suspend fun recent(symbol: String, interval: String, limit: Int): List<CandleEntity>
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/FillDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/FillDao.kt
@@ -1,0 +1,16 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.FillEntity
+
+@Dao
+interface FillDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insert(fill: FillEntity)
+
+  @Query("SELECT * FROM fills WHERE orderId = :orderId ORDER BY ts")
+  suspend fun forOrder(orderId: String): List<FillEntity>
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/IntentDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/IntentDao.kt
@@ -1,0 +1,19 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.IntentEntity
+
+@Dao
+interface IntentDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(intent: IntentEntity)
+
+  @Query("SELECT * FROM intents WHERE id = :id")
+  suspend fun findById(id: String): IntentEntity?
+
+  @Query("SELECT * FROM intents ORDER BY ts DESC LIMIT :limit")
+  suspend fun recent(limit: Int): List<IntentEntity>
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/LedgerEventDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/LedgerEventDao.kt
@@ -1,0 +1,22 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.LedgerEventEntity
+
+@Dao
+interface LedgerEventDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insert(event: LedgerEventEntity): Long
+
+  @Query("SELECT * FROM ledger_events WHERE ts >= :fromTs ORDER BY sequence ASC")
+  suspend fun listFrom(fromTs: Long): List<LedgerEventEntity>
+
+  @Query("SELECT * FROM ledger_events ORDER BY sequence ASC")
+  suspend fun listAll(): List<LedgerEventEntity>
+
+  @Query("DELETE FROM ledger_events")
+  suspend fun clear()
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/OrderDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/OrderDao.kt
@@ -1,0 +1,19 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.OrderEntity
+
+@Dao
+interface OrderDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(order: OrderEntity)
+
+  @Query("SELECT * FROM orders WHERE clientOrderId = :id")
+  suspend fun findById(id: String): OrderEntity?
+
+  @Query("UPDATE orders SET status = :status WHERE clientOrderId = :id")
+  suspend fun updateStatus(id: String, status: String)
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/PolicyDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/PolicyDao.kt
@@ -1,0 +1,16 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.PolicyEntity
+
+@Dao
+interface PolicyDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(policy: PolicyEntity)
+
+  @Query("SELECT * FROM policies WHERE policyId = :id")
+  suspend fun findById(id: String): PolicyEntity?
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/PositionDao.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/dao/PositionDao.kt
@@ -1,0 +1,22 @@
+package com.kevin.cryptotrader.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kevin.cryptotrader.persistence.entity.PositionEntity
+
+@Dao
+interface PositionDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsert(position: PositionEntity)
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun upsertAll(positions: List<PositionEntity>)
+
+  @Query("SELECT * FROM positions")
+  suspend fun listAll(): List<PositionEntity>
+
+  @Query("DELETE FROM positions")
+  suspend fun clear()
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/AutomationStateEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/AutomationStateEntity.kt
@@ -1,0 +1,12 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "automation_state")
+data class AutomationStateEntity(
+  @PrimaryKey val automationId: String,
+  val status: String,
+  val stateJson: String,
+  val updatedAt: Long,
+)

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/CandleEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/CandleEntity.kt
@@ -1,0 +1,61 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import com.kevin.cryptotrader.contracts.Candle
+import com.kevin.cryptotrader.contracts.Interval
+
+@Entity(
+  tableName = "candles",
+  primaryKeys = ["symbol", "interval", "ts", "source"],
+  indices = [Index(value = ["symbol", "interval", "ts"])],
+)
+data class CandleEntity(
+  val symbol: String,
+  val interval: String,
+  val ts: Long,
+  val open: Double,
+  val high: Double,
+  val low: Double,
+  val close: Double,
+  val volume: Double,
+  val source: String,
+) {
+  companion object {
+    fun from(
+      symbol: String,
+      interval: Interval,
+      ts: Long,
+      open: Double,
+      high: Double,
+      low: Double,
+      close: Double,
+      volume: Double,
+      source: String,
+    ): CandleEntity =
+      CandleEntity(
+        symbol = symbol,
+        interval = interval.name,
+        ts = ts,
+        open = open,
+        high = high,
+        low = low,
+        close = close,
+        volume = volume,
+        source = source,
+      )
+  }
+
+  fun toContract(): Candle =
+    Candle(
+      ts = ts,
+      open = open,
+      high = high,
+      low = low,
+      close = close,
+      volume = volume,
+      interval = Interval.valueOf(interval),
+      symbol = symbol,
+      source = source,
+    )
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/FillEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/FillEntity.kt
@@ -1,0 +1,33 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.kevin.cryptotrader.contracts.Fill
+import com.kevin.cryptotrader.contracts.Side
+
+@Entity(
+  tableName = "fills",
+  indices = [Index(value = ["orderId", "accountId", "symbol"]), Index(value = ["ts"])],
+)
+data class FillEntity(
+  @PrimaryKey(autoGenerate = true) val id: Long = 0,
+  val accountId: String,
+  val orderId: String,
+  val symbol: String,
+  val side: String,
+  val qty: Double,
+  val price: Double,
+  val ts: Long,
+) {
+  fun toContract(): Fill =
+    Fill(
+      orderId = orderId,
+      qty = qty,
+      price = price,
+      ts = ts,
+    )
+
+  val tradeSide: Side
+    get() = Side.valueOf(side)
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/IntentEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/IntentEntity.kt
@@ -1,0 +1,74 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.kevin.cryptotrader.contracts.Intent
+import com.kevin.cryptotrader.contracts.Side
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+@Entity(tableName = "intents")
+data class IntentEntity(
+  @PrimaryKey val id: String,
+  val sourceId: String,
+  val accountId: String,
+  val kind: String,
+  val symbol: String,
+  val side: String,
+  val notionalUsd: Double?,
+  val qty: Double?,
+  val priceHint: Double?,
+  val metaJson: String,
+  val ts: Long,
+) {
+  companion object {
+    fun from(
+      id: String,
+      sourceId: String,
+      accountId: String,
+      kind: String,
+      symbol: String,
+      side: String,
+      notionalUsd: Double?,
+      qty: Double?,
+      priceHint: Double?,
+      meta: Map<String, String>,
+      ts: Long,
+      json: Json,
+    ): IntentEntity {
+      val serializer = MapSerializer(String.serializer(), String.serializer())
+      return IntentEntity(
+        id = id,
+        sourceId = sourceId,
+        accountId = accountId,
+        kind = kind,
+        symbol = symbol,
+        side = side,
+        notionalUsd = notionalUsd,
+        qty = qty,
+        priceHint = priceHint,
+        metaJson = json.encodeToString(serializer, meta),
+        ts = ts,
+      )
+    }
+  }
+
+  fun meta(json: Json): Map<String, String> {
+    val serializer = MapSerializer(String.serializer(), String.serializer())
+    return json.decodeFromString(serializer, metaJson)
+  }
+
+  fun toContract(json: Json): Intent =
+    Intent(
+      id = id,
+      sourceId = sourceId,
+      kind = kind,
+      symbol = symbol,
+      side = Side.valueOf(side),
+      notionalUsd = notionalUsd,
+      qty = qty,
+      priceHint = priceHint,
+      meta = meta(json),
+    )
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/LedgerEventEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/LedgerEventEntity.kt
@@ -1,0 +1,29 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.kevin.cryptotrader.persistence.ledger.LedgerEvent
+import kotlinx.serialization.json.Json
+
+@Entity(
+  tableName = "ledger_events",
+  indices = [Index(value = ["ts"]), Index(value = ["type"])],
+)
+data class LedgerEventEntity(
+  @PrimaryKey(autoGenerate = true) val sequence: Long = 0,
+  val ts: Long,
+  val type: String,
+  val payload: String,
+) {
+  companion object {
+    fun from(event: LedgerEvent, json: Json): LedgerEventEntity =
+      LedgerEventEntity(
+        ts = event.ts,
+        type = event.type.name,
+        payload = json.encodeToString(LedgerEvent.serializer(), event),
+      )
+  }
+
+  fun toLedgerEvent(json: Json): LedgerEvent = json.decodeFromString(LedgerEvent.serializer(), payload)
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/OrderEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/OrderEntity.kt
@@ -1,0 +1,61 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.contracts.TIF
+
+@Entity(
+  tableName = "orders",
+  indices = [Index(value = ["symbol", "accountId"])],
+)
+data class OrderEntity(
+  @PrimaryKey val clientOrderId: String,
+  val accountId: String,
+  val symbol: String,
+  val side: String,
+  val type: String,
+  val qty: Double,
+  val price: Double?,
+  val stopPrice: Double?,
+  val tif: String,
+  val status: String,
+  val ts: Long,
+) {
+  companion object {
+    const val STATUS_OPEN = "OPEN"
+    const val STATUS_FILLED = "FILLED"
+    const val STATUS_CANCELED = "CANCELED"
+
+    fun from(order: Order, accountId: String, status: String = STATUS_OPEN): OrderEntity =
+      OrderEntity(
+        clientOrderId = order.clientOrderId,
+        accountId = accountId,
+        symbol = order.symbol,
+        side = order.side.name,
+        type = order.type.name,
+        qty = order.qty,
+        price = order.price,
+        stopPrice = order.stopPrice,
+        tif = order.tif.name,
+        status = status,
+        ts = order.ts,
+      )
+  }
+
+  fun toContract(): Order =
+    Order(
+      clientOrderId = clientOrderId,
+      symbol = symbol,
+      side = Side.valueOf(side),
+      type = OrderType.valueOf(type),
+      qty = qty,
+      price = price,
+      stopPrice = stopPrice,
+      tif = TIF.valueOf(tif),
+      ts = ts,
+    )
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/PolicyEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/PolicyEntity.kt
@@ -1,0 +1,13 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "policies")
+data class PolicyEntity(
+  @PrimaryKey val policyId: String,
+  val version: Int,
+  val accountId: String,
+  val configJson: String,
+  val appliedAt: Long,
+)

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/PositionEntity.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/entity/PositionEntity.kt
@@ -1,0 +1,30 @@
+package com.kevin.cryptotrader.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import com.kevin.cryptotrader.contracts.Position
+
+@Entity(
+  tableName = "positions",
+  primaryKeys = ["accountId", "symbol"],
+  indices = [Index(value = ["symbol"])],
+)
+data class PositionEntity(
+  val accountId: String,
+  val symbol: String,
+  val qty: Double,
+  val avgPrice: Double,
+  val realizedPnl: Double,
+  val unrealizedPnl: Double,
+  val lastPrice: Double?,
+) {
+  fun toContract(): Position =
+    Position(
+      accountId = accountId,
+      symbol = symbol,
+      qty = qty,
+      avgPrice = avgPrice,
+      realizedPnl = realizedPnl,
+      unrealizedPnl = unrealizedPnl,
+    )
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerEvent.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerEvent.kt
@@ -1,0 +1,110 @@
+package com.kevin.cryptotrader.persistence.ledger
+
+import com.kevin.cryptotrader.contracts.Interval
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class LedgerEvent {
+  abstract val ts: Long
+  abstract val type: Type
+
+  @Serializable
+  enum class Type {
+    CANDLE,
+    INTENT,
+    ORDER,
+    FILL,
+    POLICY,
+    AUTOMATION,
+  }
+
+  @Serializable
+  @SerialName("candle")
+  data class CandleLogged(
+    override val ts: Long,
+    val symbol: String,
+    val interval: Interval,
+    val open: Double,
+    val high: Double,
+    val low: Double,
+    val close: Double,
+    val volume: Double,
+    val source: String,
+  ) : LedgerEvent() {
+    override val type: Type = Type.CANDLE
+  }
+
+  @Serializable
+  @SerialName("intent")
+  data class IntentLogged(
+    override val ts: Long,
+    val intentId: String,
+    val sourceId: String,
+    val accountId: String,
+    val kind: String,
+    val symbol: String,
+    val side: String,
+    val notionalUsd: Double? = null,
+    val qty: Double? = null,
+    val priceHint: Double? = null,
+    val meta: Map<String, String> = emptyMap(),
+  ) : LedgerEvent() {
+    override val type: Type = Type.INTENT
+  }
+
+  @Serializable
+  @SerialName("order")
+  data class OrderPlaced(
+    override val ts: Long,
+    val orderId: String,
+    val accountId: String,
+    val symbol: String,
+    val side: String,
+    val typeName: String,
+    val qty: Double,
+    val price: Double? = null,
+    val stopPrice: Double? = null,
+    val tif: String,
+    val status: String,
+  ) : LedgerEvent() {
+    override val type: Type = Type.ORDER
+  }
+
+  @Serializable
+  @SerialName("fill")
+  data class FillRecorded(
+    override val ts: Long,
+    val orderId: String,
+    val accountId: String,
+    val symbol: String,
+    val side: String,
+    val qty: Double,
+    val price: Double,
+  ) : LedgerEvent() {
+    override val type: Type = Type.FILL
+  }
+
+  @Serializable
+  @SerialName("policy")
+  data class PolicyApplied(
+    override val ts: Long,
+    val policyId: String,
+    val accountId: String,
+    val version: Int,
+    val config: Map<String, String>,
+  ) : LedgerEvent() {
+    override val type: Type = Type.POLICY
+  }
+
+  @Serializable
+  @SerialName("automation")
+  data class AutomationStateRecorded(
+    override val ts: Long,
+    val automationId: String,
+    val status: String,
+    val state: Map<String, String>,
+  ) : LedgerEvent() {
+    override val type: Type = Type.AUTOMATION
+  }
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerMigrations.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerMigrations.kt
@@ -1,0 +1,30 @@
+package com.kevin.cryptotrader.persistence.ledger
+
+import com.kevin.cryptotrader.persistence.dao.LedgerEventDao
+import com.kevin.cryptotrader.persistence.dao.PositionDao
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+
+class LedgerMigrations(
+  private val ledgerEventDao: LedgerEventDao,
+  private val positionDao: PositionDao,
+  private val json: Json,
+) {
+  suspend fun backfillDerivedState() {
+    withContext(Dispatchers.Default) {
+      val events = ledgerEventDao.listAll()
+      if (events.isEmpty()) {
+        positionDao.clear()
+        return@withContext
+      }
+      val projector = LedgerProjector()
+      events
+        .map { it.toLedgerEvent(json) }
+        .forEach { projector.apply(it) }
+
+      positionDao.clear()
+      positionDao.upsertAll(projector.snapshot())
+    }
+  }
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerProjector.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerProjector.kt
@@ -1,0 +1,129 @@
+package com.kevin.cryptotrader.persistence.ledger
+
+import com.kevin.cryptotrader.persistence.entity.PositionEntity
+import kotlin.math.abs
+import kotlin.math.min
+
+internal class LedgerProjector {
+  private val positions = mutableMapOf<PositionKey, PositionAccumulator>()
+
+  fun seed(existing: List<PositionEntity>) {
+    existing.forEach { entity ->
+      val key = PositionKey(entity.accountId, entity.symbol)
+      positions[key] =
+        PositionAccumulator(
+          accountId = entity.accountId,
+          symbol = entity.symbol,
+          qty = entity.qty,
+          avgPrice = entity.avgPrice,
+          realizedPnl = entity.realizedPnl,
+          lastPrice = entity.lastPrice,
+        )
+    }
+  }
+
+  fun apply(event: LedgerEvent): List<PositionEntity> =
+    when (event) {
+      is LedgerEvent.FillRecorded -> listOfNotNull(applyFill(event))
+      is LedgerEvent.CandleLogged -> applyCandle(event)
+      else -> emptyList()
+    }
+
+  fun snapshot(): List<PositionEntity> = positions.values.map { it.toEntity() }
+
+  private fun applyFill(event: LedgerEvent.FillRecorded): PositionEntity? {
+    val key = PositionKey(event.accountId, event.symbol)
+    val accumulator = positions.getOrPut(key) {
+      PositionAccumulator(accountId = event.accountId, symbol = event.symbol)
+    }
+    accumulator.applyFill(event)
+    return accumulator.toEntity()
+  }
+
+  private fun applyCandle(event: LedgerEvent.CandleLogged): List<PositionEntity> {
+    val updated = mutableListOf<PositionEntity>()
+    positions.values
+      .filter { it.symbol == event.symbol }
+      .forEach { accumulator ->
+        accumulator.lastPrice = event.close
+        updated += accumulator.toEntity()
+      }
+    return updated
+  }
+
+  private data class PositionKey(
+    val accountId: String,
+    val symbol: String,
+  )
+
+  private class PositionAccumulator(
+    val accountId: String,
+    val symbol: String,
+    var qty: Double = 0.0,
+    var avgPrice: Double = 0.0,
+    var realizedPnl: Double = 0.0,
+    var lastPrice: Double? = null,
+  ) {
+    fun applyFill(event: LedgerEvent.FillRecorded) {
+      val signedQty = if (event.side.uppercase() == "BUY") event.qty else -event.qty
+      val previousQty = qty
+      val previousAvg = avgPrice
+      val newQty = previousQty + signedQty
+
+      if (previousQty == 0.0 || previousQty.sign() == signedQty.sign()) {
+        // Opening or adding to existing position
+        qty = newQty
+        avgPrice =
+          if (qty == 0.0) {
+            0.0
+          } else {
+            val totalCost = previousAvg * previousQty + event.price * signedQty
+            totalCost / qty
+          }
+      } else {
+        val closingQty = min(abs(signedQty), abs(previousQty))
+        val pnlPerUnit =
+          if (previousQty > 0) {
+            event.price - previousAvg
+          } else {
+            previousAvg - event.price
+          }
+        realizedPnl += closingQty * pnlPerUnit
+
+        qty = newQty
+        avgPrice =
+          when {
+            qty == 0.0 -> 0.0
+            previousQty.sign() != qty.sign() -> event.price
+            else -> previousAvg
+          }
+      }
+
+      lastPrice = event.price
+    }
+
+    fun toEntity(): PositionEntity {
+      val unrealized =
+        when {
+          qty > 0 && lastPrice != null -> (lastPrice!! - avgPrice) * qty
+          qty < 0 && lastPrice != null -> (avgPrice - lastPrice!!) * abs(qty)
+          else -> 0.0
+        }
+      return PositionEntity(
+        accountId = accountId,
+        symbol = symbol,
+        qty = qty,
+        avgPrice = avgPrice,
+        realizedPnl = realizedPnl,
+        unrealizedPnl = unrealized,
+        lastPrice = lastPrice,
+      )
+    }
+  }
+}
+
+private fun Double.sign(): Int = when {
+  this > 0 -> 1
+  this < 0 -> -1
+  else -> 0
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerService.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerService.kt
@@ -1,0 +1,188 @@
+package com.kevin.cryptotrader.persistence.ledger
+
+import com.kevin.cryptotrader.persistence.dao.AutomationStateDao
+import com.kevin.cryptotrader.persistence.dao.CandleDao
+import com.kevin.cryptotrader.persistence.dao.FillDao
+import com.kevin.cryptotrader.persistence.dao.IntentDao
+import com.kevin.cryptotrader.persistence.dao.LedgerEventDao
+import com.kevin.cryptotrader.persistence.dao.OrderDao
+import com.kevin.cryptotrader.persistence.dao.PolicyDao
+import com.kevin.cryptotrader.persistence.dao.PositionDao
+import com.kevin.cryptotrader.persistence.entity.AutomationStateEntity
+import com.kevin.cryptotrader.persistence.entity.CandleEntity
+import com.kevin.cryptotrader.persistence.entity.FillEntity
+import com.kevin.cryptotrader.persistence.entity.IntentEntity
+import com.kevin.cryptotrader.persistence.entity.LedgerEventEntity
+import com.kevin.cryptotrader.persistence.entity.OrderEntity
+import com.kevin.cryptotrader.persistence.entity.PolicyEntity
+import com.kevin.cryptotrader.persistence.entity.PositionEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+class LedgerService(
+  private val ledgerEventDao: LedgerEventDao,
+  private val positionDao: PositionDao,
+  private val candleDao: CandleDao? = null,
+  private val intentDao: IntentDao? = null,
+  private val orderDao: OrderDao? = null,
+  private val fillDao: FillDao? = null,
+  private val policyDao: PolicyDao? = null,
+  private val automationStateDao: AutomationStateDao? = null,
+  private val json: Json = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+    classDiscriminator = "event"
+  },
+) {
+  private val migrations = LedgerMigrations(ledgerEventDao, positionDao, json)
+  private val projector = LedgerProjector()
+  private val events = MutableSharedFlow<LedgerEvent>(extraBufferCapacity = 64)
+  private val initMutex = Mutex()
+  private var initialized = false
+
+  suspend fun initialize() {
+    ensureInitialized()
+  }
+
+  suspend fun append(event: LedgerEvent) {
+    ensureInitialized()
+    ledgerEventDao.insert(LedgerEventEntity.from(event, json))
+    persistEvent(event)
+    val updatedPositions = projector.apply(event)
+    if (updatedPositions.isNotEmpty()) {
+      positionDao.upsertAll(updatedPositions)
+    }
+    events.emit(event)
+  }
+
+  fun stream(fromTs: Long = 0L): Flow<LedgerEvent> =
+    channelFlow {
+      ensureInitialized()
+      ledgerEventDao.listFrom(fromTs).forEach { send(it.toLedgerEvent(json)) }
+      val job = launch(Dispatchers.Default) {
+        events.collect { event ->
+          if (event.ts >= fromTs) {
+            send(event)
+          }
+        }
+      }
+      awaitClose { job.cancel() }
+    }
+
+  suspend fun materialize(): LedgerSnapshot {
+    ensureInitialized()
+    val positions = positionDao.listAll().map(PositionEntity::toContract).sortedBy { it.symbol }
+    val realized = positions.sumOf { it.realizedPnl }
+    val unrealized = positions.sumOf { it.unrealizedPnl }
+    return LedgerSnapshot(positions, realized, unrealized)
+  }
+
+  private suspend fun ensureInitialized() {
+    if (initialized) return
+    initMutex.withLock {
+      if (initialized) return
+      migrations.backfillDerivedState()
+      projector.seed(positionDao.listAll())
+      initialized = true
+    }
+  }
+
+  private suspend fun persistEvent(event: LedgerEvent) {
+    when (event) {
+      is LedgerEvent.CandleLogged -> candleDao?.upsert(event.toEntity())
+      is LedgerEvent.IntentLogged -> intentDao?.upsert(event.toEntity(json))
+      is LedgerEvent.OrderPlaced -> orderDao?.upsert(event.toEntity())
+      is LedgerEvent.FillRecorded -> {
+        fillDao?.insert(event.toEntity())
+        orderDao?.updateStatus(event.orderId, OrderEntity.STATUS_FILLED)
+      }
+      is LedgerEvent.PolicyApplied -> policyDao?.upsert(event.toEntity(json))
+      is LedgerEvent.AutomationStateRecorded -> automationStateDao?.upsert(event.toEntity(json))
+    }
+  }
+}
+
+private fun LedgerEvent.CandleLogged.toEntity(): CandleEntity =
+  CandleEntity.from(
+    symbol = symbol,
+    interval = interval,
+    ts = ts,
+    open = open,
+    high = high,
+    low = low,
+    close = close,
+    volume = volume,
+    source = source,
+  )
+
+private fun LedgerEvent.IntentLogged.toEntity(json: Json): IntentEntity =
+  IntentEntity.from(
+    id = intentId,
+    sourceId = sourceId,
+    accountId = accountId,
+    kind = kind,
+    symbol = symbol,
+    side = side,
+    notionalUsd = notionalUsd,
+    qty = qty,
+    priceHint = priceHint,
+    meta = meta,
+    ts = ts,
+    json = json,
+  )
+
+private fun LedgerEvent.OrderPlaced.toEntity(): OrderEntity =
+  OrderEntity(
+    clientOrderId = orderId,
+    accountId = accountId,
+    symbol = symbol,
+    side = side,
+    type = typeName,
+    qty = qty,
+    price = price,
+    stopPrice = stopPrice,
+    tif = tif,
+    status = status,
+    ts = ts,
+  )
+
+private fun LedgerEvent.FillRecorded.toEntity(): FillEntity =
+  FillEntity(
+    accountId = accountId,
+    orderId = orderId,
+    symbol = symbol,
+    side = side,
+    qty = qty,
+    price = price,
+    ts = ts,
+  )
+
+private fun LedgerEvent.PolicyApplied.toEntity(json: Json): PolicyEntity {
+  val serializer = MapSerializer(String.serializer(), String.serializer())
+  return PolicyEntity(
+    policyId = policyId,
+    version = version,
+    accountId = accountId,
+    configJson = json.encodeToString(serializer, config),
+    appliedAt = ts,
+  )
+}
+
+private fun LedgerEvent.AutomationStateRecorded.toEntity(json: Json): AutomationStateEntity {
+  val serializer = MapSerializer(String.serializer(), String.serializer())
+  return AutomationStateEntity(
+    automationId = automationId,
+    status = status,
+    stateJson = json.encodeToString(serializer, state),
+    updatedAt = ts,
+  )
+}

--- a/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerSnapshot.kt
+++ b/persistence/src/main/kotlin/com/kevin/cryptotrader/persistence/ledger/LedgerSnapshot.kt
@@ -1,0 +1,9 @@
+package com.kevin.cryptotrader.persistence.ledger
+
+import com.kevin.cryptotrader.contracts.Position
+
+data class LedgerSnapshot(
+  val positions: List<Position>,
+  val totalRealizedPnl: Double,
+  val totalUnrealizedPnl: Double,
+)

--- a/persistence/src/test/kotlin/com/kevin/cryptotrader/persistence/LedgerServiceParityTest.kt
+++ b/persistence/src/test/kotlin/com/kevin/cryptotrader/persistence/LedgerServiceParityTest.kt
@@ -1,0 +1,316 @@
+package com.kevin.cryptotrader.persistence
+
+import com.kevin.cryptotrader.contracts.Interval
+import com.kevin.cryptotrader.persistence.dao.LedgerEventDao
+import com.kevin.cryptotrader.persistence.dao.PositionDao
+import com.kevin.cryptotrader.persistence.entity.LedgerEventEntity
+import com.kevin.cryptotrader.persistence.entity.PositionEntity
+import com.kevin.cryptotrader.persistence.ledger.LedgerEvent
+import com.kevin.cryptotrader.persistence.ledger.LedgerService
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LedgerServiceParityTest {
+  private val json = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+    classDiscriminator = "event"
+  }
+
+  @Test
+  fun replayingLedgerBackfillsDerivedState() = runTest {
+    val ledgerDao = InMemoryLedgerEventDao()
+    val positionDao = InMemoryPositionDao()
+    val service = LedgerService(
+      ledgerEventDao = ledgerDao,
+      positionDao = positionDao,
+      json = json,
+    )
+    service.initialize()
+
+    val baseTs = 1_000L
+    service.append(
+      LedgerEvent.CandleLogged(
+        ts = baseTs,
+        symbol = "BTCUSDT",
+        interval = Interval.H1,
+        open = 30000.0,
+        high = 30500.0,
+        low = 29500.0,
+        close = 30000.0,
+        volume = 100.0,
+        source = "binance",
+      ),
+    )
+    service.append(
+      LedgerEvent.OrderPlaced(
+        ts = baseTs + 1,
+        orderId = "order-1",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "BUY",
+        typeName = "MARKET",
+        qty = 2.0,
+        price = null,
+        stopPrice = null,
+        tif = "GTC",
+        status = "FILLED",
+      ),
+    )
+    service.append(
+      LedgerEvent.FillRecorded(
+        ts = baseTs + 2,
+        orderId = "order-1",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "BUY",
+        qty = 2.0,
+        price = 30000.0,
+      ),
+    )
+    service.append(
+      LedgerEvent.CandleLogged(
+        ts = baseTs + 3,
+        symbol = "BTCUSDT",
+        interval = Interval.H1,
+        open = 30000.0,
+        high = 32500.0,
+        low = 29900.0,
+        close = 32000.0,
+        volume = 85.0,
+        source = "binance",
+      ),
+    )
+    service.append(
+      LedgerEvent.OrderPlaced(
+        ts = baseTs + 4,
+        orderId = "order-2",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "SELL",
+        typeName = "LIMIT",
+        qty = 0.5,
+        price = 35000.0,
+        stopPrice = null,
+        tif = "GTC",
+        status = "FILLED",
+      ),
+    )
+    service.append(
+      LedgerEvent.FillRecorded(
+        ts = baseTs + 5,
+        orderId = "order-2",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "SELL",
+        qty = 0.5,
+        price = 35000.0,
+      ),
+    )
+    service.append(
+      LedgerEvent.CandleLogged(
+        ts = baseTs + 6,
+        symbol = "BTCUSDT",
+        interval = Interval.H1,
+        open = 32000.0,
+        high = 34000.0,
+        low = 31500.0,
+        close = 33000.0,
+        volume = 70.0,
+        source = "binance",
+      ),
+    )
+    service.append(
+      LedgerEvent.OrderPlaced(
+        ts = baseTs + 7,
+        orderId = "order-3",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "SELL",
+        typeName = "LIMIT",
+        qty = 1.5,
+        price = 29000.0,
+        stopPrice = null,
+        tif = "GTC",
+        status = "FILLED",
+      ),
+    )
+    service.append(
+      LedgerEvent.FillRecorded(
+        ts = baseTs + 8,
+        orderId = "order-3",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "SELL",
+        qty = 1.5,
+        price = 29000.0,
+      ),
+    )
+    service.append(
+      LedgerEvent.CandleLogged(
+        ts = baseTs + 9,
+        symbol = "BTCUSDT",
+        interval = Interval.H1,
+        open = 30000.0,
+        high = 30200.0,
+        low = 28000.0,
+        close = 28000.0,
+        volume = 60.0,
+        source = "binance",
+      ),
+    )
+    service.append(
+      LedgerEvent.OrderPlaced(
+        ts = baseTs + 10,
+        orderId = "order-4",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "SELL",
+        typeName = "MARKET",
+        qty = 1.0,
+        price = 27000.0,
+        stopPrice = null,
+        tif = "GTC",
+        status = "FILLED",
+      ),
+    )
+    service.append(
+      LedgerEvent.FillRecorded(
+        ts = baseTs + 11,
+        orderId = "order-4",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "SELL",
+        qty = 1.0,
+        price = 27000.0,
+      ),
+    )
+    service.append(
+      LedgerEvent.CandleLogged(
+        ts = baseTs + 12,
+        symbol = "BTCUSDT",
+        interval = Interval.H1,
+        open = 27500.0,
+        high = 28000.0,
+        low = 24000.0,
+        close = 25000.0,
+        volume = 55.0,
+        source = "binance",
+      ),
+    )
+    service.append(
+      LedgerEvent.OrderPlaced(
+        ts = baseTs + 13,
+        orderId = "order-5",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "BUY",
+        typeName = "LIMIT",
+        qty = 0.4,
+        price = 20000.0,
+        stopPrice = null,
+        tif = "GTC",
+        status = "FILLED",
+      ),
+    )
+    service.append(
+      LedgerEvent.FillRecorded(
+        ts = baseTs + 14,
+        orderId = "order-5",
+        accountId = "acct-1",
+        symbol = "BTCUSDT",
+        side = "BUY",
+        qty = 0.4,
+        price = 20000.0,
+      ),
+    )
+    service.append(
+      LedgerEvent.CandleLogged(
+        ts = baseTs + 15,
+        symbol = "BTCUSDT",
+        interval = Interval.H1,
+        open = 24000.0,
+        high = 27000.0,
+        low = 24000.0,
+        close = 26000.0,
+        volume = 48.0,
+        source = "binance",
+      ),
+    )
+
+    val incrementalSnapshot = service.materialize()
+
+    val replayPositionDao = InMemoryPositionDao()
+    val replayService = LedgerService(
+      ledgerEventDao = ledgerDao,
+      positionDao = replayPositionDao,
+      json = json,
+    )
+    replayService.initialize()
+    val replaySnapshot = replayService.materialize()
+
+    assertEquals(incrementalSnapshot.positions, replaySnapshot.positions)
+    assertEquals(incrementalSnapshot.totalRealizedPnl, replaySnapshot.totalRealizedPnl, 1e-6)
+    assertEquals(incrementalSnapshot.totalUnrealizedPnl, replaySnapshot.totalUnrealizedPnl, 1e-6)
+
+    val position = replaySnapshot.positions.single()
+    assertEquals("acct-1", position.accountId)
+    assertEquals("BTCUSDT", position.symbol)
+    assertEquals(-0.6, position.qty, 1e-6)
+    assertEquals(27000.0, position.avgPrice, 1e-6)
+    assertEquals(3800.0, position.realizedPnl, 1e-6)
+    assertEquals(600.0, position.unrealizedPnl, 1e-6)
+  }
+}
+
+private class InMemoryLedgerEventDao : LedgerEventDao {
+  private val mutex = Mutex()
+  private val events = mutableListOf<LedgerEventEntity>()
+  private var nextId = 1L
+
+  override suspend fun insert(event: LedgerEventEntity): Long =
+    mutex.withLock {
+      val stored = event.copy(sequence = nextId++)
+      events += stored
+      stored.sequence
+    }
+
+  override suspend fun listFrom(fromTs: Long): List<LedgerEventEntity> =
+    mutex.withLock { events.filter { it.ts >= fromTs }.sortedBy { it.sequence } }
+
+  override suspend fun listAll(): List<LedgerEventEntity> = mutex.withLock { events.sortedBy { it.sequence } }
+
+  override suspend fun clear() {
+    mutex.withLock {
+      events.clear()
+      nextId = 1L
+    }
+  }
+}
+
+private class InMemoryPositionDao : PositionDao {
+  private val mutex = Mutex()
+  private val positions = linkedMapOf<Pair<String, String>, PositionEntity>()
+
+  override suspend fun upsert(position: PositionEntity) {
+    mutex.withLock { positions[position.accountId to position.symbol] = position }
+  }
+
+  override suspend fun upsertAll(positions: List<PositionEntity>) {
+    mutex.withLock {
+      positions.forEach { entity ->
+        this.positions[entity.accountId to entity.symbol] = entity
+      }
+    }
+  }
+
+  override suspend fun listAll(): List<PositionEntity> = mutex.withLock { positions.values.map { it.copy() } }
+
+  override suspend fun clear() {
+    mutex.withLock { positions.clear() }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,4 +28,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "CryptoTrader"
-include(":contracts", ":core", ":data", ":runtime", ":paperbroker", ":ui", ":mocks", ":tools", ":app")
+include(":contracts", ":core", ":data", ":runtime", ":paperbroker", ":ui", ":mocks", ":tools", ":app", ":persistence")


### PR DESCRIPTION
## Summary
- add a new persistence module that defines Room entities, DAOs, and a TraderDatabase facade for market data, intents, orders, fills, positions, policies, automation state, and ledger events
- implement an event-sourced ledger service with append, stream, materialize flows plus backfill migrations that rebuild derived position state from historical events
- cover the service with parity tests that replay the ledger and assert positions and PnL match the incrementally maintained snapshot

## Testing
- ./gradlew :persistence:test

------
https://chatgpt.com/codex/tasks/task_e_68e1760c41ec83218f32ce02755bd669