### PR TITLE
Add fixture-backed exchange adapters and metadata loaders

### DIFF
--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/BaseFixtureMarketDataAdapter.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/BaseFixtureMarketDataAdapter.kt
@@ -1,0 +1,173 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Candle
+import com.kevin.cryptotrader.contracts.Interval
+import com.kevin.cryptotrader.contracts.MarketDataFeed
+import com.kevin.cryptotrader.contracts.OrderBookDelta
+import com.kevin.cryptotrader.contracts.Ticker
+import com.kevin.cryptotrader.contracts.Trade
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.merge
+
+abstract class BaseFixtureMarketDataAdapter(
+  private val source: String,
+  private val cache: OhlcvCache,
+  private val provider: FixtureOhlcvProvider,
+) : MarketDataFeed {
+
+  override suspend fun fetchOhlcv(
+    symbol: String,
+    tf: Interval,
+    start: Long?,
+    end: Long?,
+    limit: Int?,
+  ): List<Candle> {
+    val normalizedSymbol = normalizeSymbol(symbol)
+    val cached = cache.query(normalizedSymbol, tf, start, end, limit)
+    val needsBackfill = cached.isEmpty() ||
+      (start != null && (cached.firstOrNull()?.ts ?: Long.MAX_VALUE) > start)
+    if (!needsBackfill) {
+      return cached
+    }
+
+    val candles = provider.load(normalizedSymbol, tf, source)
+    cache.upsert(candles)
+    return cache.query(normalizedSymbol, tf, start, end, limit)
+  }
+
+  override fun streamTicker(symbols: Set<String>): Flow<Ticker> {
+    val flows = symbols.map { symbol ->
+      val normalized = normalizeSymbol(symbol)
+      channelFlow {
+        val backfill = cache.query(normalized, defaultStreamInterval(), limit = backfillDepth())
+        for (candle in backfill) {
+          send(Ticker(ts = candle.ts, symbol = normalized, price = candle.close))
+        }
+        for (candle in provider.load(normalized, defaultStreamInterval(), source)) {
+          cache.upsert(listOf(candle))
+          send(Ticker(ts = candle.ts, symbol = normalized, price = candle.close))
+        }
+      }
+    }
+    if (flows.isEmpty()) return emptyFlow()
+    return merge(*flows.toTypedArray())
+  }
+
+  override fun streamTrades(symbols: Set<String>): Flow<Trade> {
+    val flows = symbols.map { symbol ->
+      val normalized = normalizeSymbol(symbol)
+      channelFlow {
+        val backfill = cache.query(normalized, defaultStreamInterval(), limit = backfillDepth())
+        for (candle in backfill) {
+          send(
+            Trade(
+              ts = candle.ts,
+              symbol = normalized,
+              price = candle.close,
+              qty = candle.volume,
+              isBuy = true,
+            ),
+          )
+        }
+        for (candle in provider.load(normalized, defaultStreamInterval(), source)) {
+          cache.upsert(listOf(candle))
+          send(
+            Trade(
+              ts = candle.ts,
+              symbol = normalized,
+              price = candle.close,
+              qty = candle.volume,
+              isBuy = candle.close >= candle.open,
+            ),
+          )
+        }
+      }
+    }
+    if (flows.isEmpty()) return emptyFlow()
+    return merge(*flows.toTypedArray())
+  }
+
+  override fun streamBook(symbols: Set<String>): Flow<OrderBookDelta> {
+    val flows = symbols.map { symbol ->
+      val normalized = normalizeSymbol(symbol)
+      channelFlow {
+        val backfill = cache.query(normalized, defaultStreamInterval(), limit = backfillDepth())
+        for (candle in backfill) {
+          send(candle.toBookDelta())
+        }
+        for (candle in provider.load(normalized, defaultStreamInterval(), source)) {
+          cache.upsert(listOf(candle))
+          send(candle.toBookDelta())
+        }
+      }
+    }
+    if (flows.isEmpty()) return emptyFlow()
+    return merge(*flows.toTypedArray())
+  }
+
+  private fun Candle.toBookDelta(): OrderBookDelta {
+    val mid = close
+    val bid = (mid * 0.999).coerceAtLeast(low)
+    val ask = (mid * 1.001).coerceAtMost(high)
+    return OrderBookDelta(
+      ts = ts,
+      symbol = symbol,
+      bids = listOf(bid to volume / 2),
+      asks = listOf(ask to volume / 2),
+    )
+  }
+
+  protected open fun defaultStreamInterval(): Interval = Interval.H1
+
+  protected open fun backfillDepth(): Int = 20
+
+  fun streamUserEvents(accountId: String, symbols: Set<String>): Flow<UserStreamEvent> = channelFlow {
+    for (symbol in symbols) {
+      val normalized = normalizeSymbol(symbol)
+      val candles = provider.load(normalized, defaultStreamInterval(), source)
+      if (candles.isEmpty()) continue
+      val first = candles.first()
+      send(
+        UserStreamEvent.BalanceUpdate(
+          venue = source,
+          accountId = accountId,
+          asset = normalized.takeLast(3),
+          free = first.volume,
+        ),
+      )
+      for (candle in candles) {
+        send(
+          UserStreamEvent.OrderFill(
+            venue = source,
+            accountId = accountId,
+            symbol = normalized,
+            price = candle.close,
+            qty = candle.volume / 10,
+          ),
+        )
+      }
+    }
+  }
+
+  sealed interface UserStreamEvent {
+    val venue: String
+    val accountId: String
+
+    data class BalanceUpdate(
+      override val venue: String,
+      override val accountId: String,
+      val asset: String,
+      val free: Double,
+    ) : UserStreamEvent
+
+    data class OrderFill(
+      override val venue: String,
+      override val accountId: String,
+      val symbol: String,
+      val price: Double,
+      val qty: Double,
+    ) : UserStreamEvent
+  }
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/BinanceMarketDataAdapter.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/BinanceMarketDataAdapter.kt
@@ -1,0 +1,16 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Interval
+
+class BinanceMarketDataAdapter(
+  cache: OhlcvCache,
+  provider: FixtureOhlcvProvider = FixtureOhlcvProvider(),
+) : BaseFixtureMarketDataAdapter(
+  source = "binance",
+  cache = cache,
+  provider = provider,
+) {
+  override fun backfillDepth(): Int = 50
+
+  override fun defaultStreamInterval(): Interval = Interval.H1
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/CoinbaseMarketDataAdapter.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/CoinbaseMarketDataAdapter.kt
@@ -1,0 +1,16 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Interval
+
+class CoinbaseMarketDataAdapter(
+  cache: OhlcvCache,
+  provider: FixtureOhlcvProvider = FixtureOhlcvProvider(),
+) : BaseFixtureMarketDataAdapter(
+  source = "coinbase",
+  cache = cache,
+  provider = provider,
+) {
+  override fun backfillDepth(): Int = 30
+
+  override fun defaultStreamInterval(): Interval = Interval.H1
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/MetadataLoader.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/MetadataLoader.kt
@@ -1,0 +1,88 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Interval
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.nio.file.Path
+
+@Serializable
+private data class CoinGeckoSnapshot(
+  val assets: List<CoinGeckoAsset>,
+)
+
+@Serializable
+private data class CoinGeckoAsset(
+  val id: String,
+  val symbol: String,
+  val name: String,
+  @SerialName("tick_size") val tickSize: Double,
+  @SerialName("lot_size") val lotSize: Double,
+  val venues: List<String>,
+  val timeframes: List<String>,
+)
+
+@Serializable
+private data class DexAggregatorConfig(
+  val aggregators: List<DexAggregator>,
+)
+
+@Serializable
+data class DexAggregator(
+  val id: String,
+  val name: String,
+  val supportsLimitOrders: Boolean = false,
+)
+
+data class AssetMetadata(
+  val id: String,
+  val symbol: String,
+  val name: String,
+  val tickSize: Double,
+  val lotSize: Double,
+  val venues: Set<String>,
+  val timeframes: Set<Interval>,
+)
+
+class CoinGeckoMetadataLoader(
+  private val snapshotPath: Path,
+  private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+  fun load(): List<AssetMetadata> {
+    val snapshot = json.decodeFromString<CoinGeckoSnapshot>(snapshotPath.toFile().readText())
+    return snapshot.assets.map { asset ->
+      AssetMetadata(
+        id = asset.id,
+        symbol = normalizeSymbol(asset.symbol),
+        name = asset.name,
+        tickSize = asset.tickSize,
+        lotSize = asset.lotSize,
+        venues = asset.venues.map { it.lowercase() }.toSet(),
+        timeframes = asset.timeframes.mapNotNull { it.toInterval() }.toSet(),
+      )
+    }
+  }
+}
+
+class DexAggregatorMetadataLoader(
+  private val configPath: Path?,
+  private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+  fun load(): List<DexAggregator> {
+    val path = configPath ?: return emptyList()
+    if (!path.toFile().exists()) return emptyList()
+    val config = json.decodeFromString<DexAggregatorConfig>(path.toFile().readText())
+    return config.aggregators
+  }
+}
+
+private fun String.toInterval(): Interval? = when (lowercase()) {
+  "1m" -> Interval.M1
+  "5m" -> Interval.M5
+  "15m" -> Interval.M15
+  "30m" -> Interval.M30
+  "1h" -> Interval.H1
+  "4h" -> Interval.H4
+  "1d" -> Interval.D1
+  else -> null
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/OhlcvCache.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/OhlcvCache.kt
@@ -1,0 +1,57 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Candle
+import com.kevin.cryptotrader.contracts.Interval
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Lightweight in-memory cache that emulates the behaviour of the Room-backed cache that
+ * the production app will use. The Room schema is intentionally mirrored so the cache can
+ * be swapped out with the generated DAO without touching the adapters.
+ */
+class OhlcvCache {
+  private data class CacheKey(val symbol: String, val interval: Interval)
+
+  private val mutex = Mutex()
+  private val storage = mutableMapOf<CacheKey, MutableList<Candle>>()
+
+  suspend fun upsert(candles: Collection<Candle>) {
+    if (candles.isEmpty()) return
+    mutex.withLock {
+      candles.groupBy { CacheKey(it.symbol, it.interval) }.forEach { (key, grouped) ->
+        val existing = storage.getOrPut(key) { mutableListOf() }
+        val deduped = (existing + grouped)
+          .distinctBy { it.ts }
+          .sortedBy { it.ts }
+        storage[key] = deduped.toMutableList()
+      }
+    }
+  }
+
+  suspend fun query(
+    symbol: String,
+    interval: Interval,
+    start: Long? = null,
+    end: Long? = null,
+    limit: Int? = null,
+  ): List<Candle> {
+    return mutex.withLock {
+      val key = CacheKey(symbol, interval)
+      val data = storage[key]?.asSequence() ?: emptySequence()
+      val filtered = data
+        .filter { start == null || it.ts >= start }
+        .filter { end == null || it.ts <= end }
+        .toList()
+      if (limit != null && filtered.size > limit) {
+        filtered.takeLast(limit)
+      } else {
+        filtered
+      }
+    }
+  }
+
+  suspend fun last(symbol: String, interval: Interval): Candle? = mutex.withLock {
+    storage[CacheKey(symbol, interval)]?.lastOrNull()
+  }
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/SymbolUtils.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/marketdata/SymbolUtils.kt
@@ -1,0 +1,61 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Candle
+import com.kevin.cryptotrader.contracts.Interval
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+
+internal fun normalizeSymbol(symbol: String): String = symbol
+  .replace("-", "")
+  .replace("/", "")
+  .uppercase()
+
+internal fun normalizeIntervalLabel(interval: Interval): String = when (interval) {
+  Interval.M1 -> "1m"
+  Interval.M5 -> "5m"
+  Interval.M15 -> "15m"
+  Interval.M30 -> "30m"
+  Interval.H1 -> "1h"
+  Interval.H4 -> "4h"
+  Interval.D1 -> "1d"
+}
+
+fun resolveFixturesRoot(): Path {
+  var current: Path? = Paths.get("").toAbsolutePath()
+  repeat(6) {
+    val candidate = current?.resolve("fixtures")
+    if (candidate != null && candidate.exists()) return candidate
+    current = current?.parent
+  }
+  error("Unable to locate fixtures directory")
+}
+
+class FixtureOhlcvProvider(private val fixtureRoot: Path = resolveFixturesRoot().resolve("ohlcv")) {
+  fun load(symbol: String, interval: Interval, source: String): List<Candle> {
+    val normalized = normalizeSymbol(symbol)
+    val filename = "${normalized}_${normalizeIntervalLabel(interval)}_sample.csv"
+    val path = fixtureRoot.resolve(filename)
+    require(path.isRegularFile()) { "Missing OHLCV fixture $filename" }
+    return Files.readAllLines(path)
+      .drop(1)
+      .filter { it.isNotBlank() }
+      .map { line ->
+        val parts = line.split(',')
+        require(parts.size >= 6) { "Invalid candle line: $line" }
+        Candle(
+          ts = parts[0].trim().toLong(),
+          open = parts[1].trim().toDouble(),
+          high = parts[2].trim().toDouble(),
+          low = parts[3].trim().toDouble(),
+          close = parts[4].trim().toDouble(),
+          volume = parts[5].trim().toDouble(),
+          interval = interval,
+          symbol = normalized,
+          source = source,
+        )
+      }
+  }
+}

--- a/data/src/test/kotlin/com/kevin/cryptotrader/data/marketdata/BinanceMarketDataAdapterTest.kt
+++ b/data/src/test/kotlin/com/kevin/cryptotrader/data/marketdata/BinanceMarketDataAdapterTest.kt
@@ -1,0 +1,43 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Interval
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BinanceMarketDataAdapterTest {
+  private val cache = OhlcvCache()
+  private val provider = FixtureOhlcvProvider()
+  private val adapter = BinanceMarketDataAdapter(cache, provider)
+
+  @Test
+  fun `fetchOhlcv seeds cache and respects limits`() = runBlocking {
+    val candles = adapter.fetchOhlcv("btc/usdt", Interval.H1, limit = 3)
+    assertEquals(3, candles.size)
+    assertTrue(candles.zipWithNext().all { (a, b) -> a.ts < b.ts })
+
+    val cached = adapter.fetchOhlcv("BTCUSDT", Interval.H1, limit = 3)
+    assertEquals(candles, cached)
+  }
+
+  @Test
+  fun `streaming tickers emit backfill followed by live updates`() = runBlocking {
+    val events = adapter.streamTicker(setOf("BTCUSDT"))
+      .take(5)
+      .toList()
+    assertEquals(5, events.size)
+    assertTrue(events.zipWithNext().all { (a, b) -> a.ts <= b.ts })
+  }
+
+  @Test
+  fun `user stream emits balance and fills`() = runBlocking {
+    val events = adapter.streamUserEvents("acct-1", setOf("BTCUSDT"))
+      .take(3)
+      .toList()
+    assertTrue(events.first() is BaseFixtureMarketDataAdapter.UserStreamEvent.BalanceUpdate)
+    assertTrue(events.drop(1).all { it is BaseFixtureMarketDataAdapter.UserStreamEvent.OrderFill })
+  }
+}

--- a/data/src/test/kotlin/com/kevin/cryptotrader/data/marketdata/CoinbaseMarketDataAdapterTest.kt
+++ b/data/src/test/kotlin/com/kevin/cryptotrader/data/marketdata/CoinbaseMarketDataAdapterTest.kt
@@ -1,0 +1,32 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import com.kevin.cryptotrader.contracts.Interval
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoinbaseMarketDataAdapterTest {
+  private val cache = OhlcvCache()
+  private val provider = FixtureOhlcvProvider()
+  private val adapter = CoinbaseMarketDataAdapter(cache, provider)
+
+  @Test
+  fun `fetch backfills and caches`() = runBlocking {
+    val candles = adapter.fetchOhlcv("ETH-USDT", Interval.H1, start = 1672531200000, limit = 2)
+    assertEquals(2, candles.size)
+    val cached = adapter.fetchOhlcv("ETHUSDT", Interval.H1, limit = 2)
+    assertEquals(candles, cached)
+  }
+
+  @Test
+  fun `trade stream contains deterministic backfill`() = runBlocking {
+    val trades = adapter.streamTrades(setOf("ETHUSDT"))
+      .take(4)
+      .toList()
+    assertEquals(4, trades.size)
+    assertTrue(trades.all { it.symbol == "ETHUSDT" })
+  }
+}

--- a/data/src/test/kotlin/com/kevin/cryptotrader/data/marketdata/MetadataLoaderTest.kt
+++ b/data/src/test/kotlin/com/kevin/cryptotrader/data/marketdata/MetadataLoaderTest.kt
@@ -1,0 +1,30 @@
+package com.kevin.cryptotrader.data.marketdata
+
+import kotlinx.serialization.json.Json
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MetadataLoaderTest {
+  private val fixturesRoot: Path = resolveFixturesRoot().resolve("metadata")
+
+  @Test
+  fun `coin gecko loader normalizes symbols and intervals`() {
+    val loader = CoinGeckoMetadataLoader(fixturesRoot.resolve("coingecko_snapshot.json"), Json)
+    val assets = loader.load()
+    val bitcoin = assets.first { it.symbol == "BTC" }
+    assertEquals(setOf("binance", "coinbase"), bitcoin.venues)
+    assertTrue(bitcoin.timeframes.containsAll(listOf(com.kevin.cryptotrader.contracts.Interval.H1, com.kevin.cryptotrader.contracts.Interval.D1)))
+  }
+
+  @Test
+  fun `dex aggregator loader is optional`() {
+    val loader = DexAggregatorMetadataLoader(fixturesRoot.resolve("dex_aggregators.json"), Json)
+    val aggregators = loader.load()
+    assertEquals(2, aggregators.size)
+
+    val missingLoader = DexAggregatorMetadataLoader(fixturesRoot.resolve("missing.json"), Json)
+    assertTrue(missingLoader.load().isEmpty())
+  }
+}

--- a/fixtures/metadata/coingecko_snapshot.json
+++ b/fixtures/metadata/coingecko_snapshot.json
@@ -1,0 +1,22 @@
+{
+  "assets": [
+    {
+      "id": "bitcoin",
+      "symbol": "btc",
+      "name": "Bitcoin",
+      "tick_size": 0.01,
+      "lot_size": 0.0001,
+      "venues": ["Binance", "Coinbase"],
+      "timeframes": ["1h", "1d"]
+    },
+    {
+      "id": "ethereum",
+      "symbol": "eth",
+      "name": "Ethereum",
+      "tick_size": 0.01,
+      "lot_size": 0.001,
+      "venues": ["Binance"],
+      "timeframes": ["1h", "4h", "1d"]
+    }
+  ]
+}

--- a/fixtures/metadata/dex_aggregators.json
+++ b/fixtures/metadata/dex_aggregators.json
@@ -1,0 +1,6 @@
+{
+  "aggregators": [
+    {"id": "0x", "name": "0x API", "supportsLimitOrders": false},
+    {"id": "1inch", "name": "1inch", "supportsLimitOrders": true}
+  ]
+}


### PR DESCRIPTION
## Summary
- add Binance and Coinbase market data adapters with shared fixture-backed base implementation and OHLCV cache
- introduce CoinGecko and DEX aggregator metadata loaders with normalization helpers and fixtures
- cover the new adapters and loaders with regression-style tests backed by repository fixtures

## Testing
- ./gradlew :data:test

------
https://chatgpt.com/codex/tasks/task_e_68e1761dbdfc83218fb2589bf017c2db