### PR TITLE
Implement funding adapters and portfolio aggregation

### DIFF
--- a/contracts/src/main/kotlin/com/kevin/cryptotrader/contracts/DomainModels.kt
+++ b/contracts/src/main/kotlin/com/kevin/cryptotrader/contracts/DomainModels.kt
@@ -127,6 +127,8 @@ data class TransferPlan(
   val steps: List<TransferStep>,
   val totalCostUsd: Double,
   val etaSeconds: Long,
+  val costBreakdown: CostBreakdown = CostBreakdown(),
+  val safetyChecks: List<PlanSafetyCheck> = emptyList(),
 )
 
 sealed class TransferStep {
@@ -155,6 +157,16 @@ sealed class TransferStep {
     val asset: String,
     val amount: Double,
   ) : TransferStep()
+
+  data class WalletTransfer(
+    val walletId: AccountId,
+    val toAddress: String,
+    val asset: String,
+    val network: String,
+    val amount: Double,
+    val connector: String,
+    val memo: String? = null,
+  ) : TransferStep()
 }
 
 data class PlanPrefs(
@@ -167,6 +179,28 @@ data class PlanStatus(
   val stepIndex: Int,
   val state: String,
   val error: String? = null,
+)
+
+data class CostBreakdown(
+  val notionalUsd: Double = 0.0,
+  val tradingFeesUsd: Double = 0.0,
+  val withdrawalFeesUsd: Double = 0.0,
+  val networkFeesUsd: Double = 0.0,
+) {
+  val totalFeesUsd: Double
+    get() = tradingFeesUsd + withdrawalFeesUsd + networkFeesUsd
+
+  val totalCostUsd: Double
+    get() = notionalUsd + totalFeesUsd
+}
+
+enum class SafetyStatus { PASSED, WARNING, PENDING }
+
+data class PlanSafetyCheck(
+  val id: String,
+  val description: String,
+  val status: SafetyStatus,
+  val blocking: Boolean = true,
 )
 
 data class AutomationDef(

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/funding/FundingConfig.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/funding/FundingConfig.kt
@@ -1,0 +1,138 @@
+package com.kevin.cryptotrader.data.funding
+
+import com.kevin.cryptotrader.contracts.AccountId
+
+data class WithdrawalNetworkFee(
+  val network: String,
+  val feeUsd: Double,
+  val minAmount: Double,
+  val etaSeconds: Long,
+  val allowlistRequired: Boolean = true,
+)
+
+data class TradingProfile(
+  val exchangeId: String,
+  val tradingFeeBps: Double,
+  val withdrawalFees: Map<String, List<WithdrawalNetworkFee>>,
+  val internalTransferFeeBps: Double = 0.0,
+)
+
+data class DepositAddress(
+  val address: String,
+  val memo: String? = null,
+  val whitelisted: Boolean = true,
+)
+
+data class WalletProfile(
+  val accountId: AccountId,
+  val connectorId: String,
+  val addresses: Map<String, String>,
+  val gasFeeUsd: Map<String, Double>,
+)
+
+data class FundingConfig(
+  val tradingProfiles: Map<String, TradingProfile>,
+  val depositAddresses: Map<AccountId, Map<String, Map<String, DepositAddress>>>,
+  val walletProfiles: Map<AccountId, WalletProfile>,
+  val priceQuotes: Map<String, Map<String, Double>>,
+) {
+  fun tradingProfileFor(venueId: String): TradingProfile? = tradingProfiles[venueId.lowercase()]
+
+  fun walletProfile(accountId: AccountId): WalletProfile? = walletProfiles[accountId]
+
+  fun depositAddress(accountId: AccountId, asset: String, network: String): DepositAddress? {
+    return depositAddresses[accountId]
+      ?.get(asset.uppercase())
+      ?.get(network.uppercase())
+  }
+
+  fun quotePrice(venueId: String, asset: String): Double? =
+    priceQuotes[venueId.lowercase()]?.get(asset.uppercase())
+}
+
+object FundingFixtures {
+  fun default(): FundingConfig {
+    val tradingProfiles = mapOf(
+      "binance" to TradingProfile(
+        exchangeId = "binance",
+        tradingFeeBps = 8.0,
+        withdrawalFees = mapOf(
+          "USDT" to listOf(
+            WithdrawalNetworkFee(network = "ETH", feeUsd = 5.0, minAmount = 10.0, etaSeconds = 600),
+            WithdrawalNetworkFee(network = "TRX", feeUsd = 1.0, minAmount = 10.0, etaSeconds = 300),
+          ),
+          "BTC" to listOf(
+            WithdrawalNetworkFee(network = "BTC", feeUsd = 8.0, minAmount = 0.001, etaSeconds = 1800),
+          ),
+        ),
+        internalTransferFeeBps = 0.0,
+      ),
+      "coinbase" to TradingProfile(
+        exchangeId = "coinbase",
+        tradingFeeBps = 35.0,
+        withdrawalFees = mapOf(
+          "USDT" to listOf(
+            WithdrawalNetworkFee(network = "ETH", feeUsd = 8.0, minAmount = 10.0, etaSeconds = 900),
+          ),
+          "BTC" to listOf(
+            WithdrawalNetworkFee(network = "BTC", feeUsd = 10.0, minAmount = 0.001, etaSeconds = 2400),
+          ),
+        ),
+        internalTransferFeeBps = 0.0,
+      ),
+    )
+
+    val depositAddresses = mapOf(
+      "acc_coinbase" to mapOf(
+        "USDT" to mapOf(
+          "ETH" to DepositAddress(address = "0xCOINBASEDEPOSIT", memo = null, whitelisted = true),
+        ),
+        "BTC" to mapOf(
+          "BTC" to DepositAddress(address = "bc1-coinbase", memo = null, whitelisted = true),
+        ),
+      ),
+      "acc_binance" to mapOf(
+        "USDT" to mapOf(
+          "ETH" to DepositAddress(address = "0xBINANCEUSDT", memo = null, whitelisted = true),
+          "TRX" to DepositAddress(address = "TBinance", memo = null, whitelisted = true),
+        ),
+        "BTC" to mapOf(
+          "BTC" to DepositAddress(address = "bc1-binance", memo = null, whitelisted = true),
+        ),
+      ),
+    )
+
+    val walletProfiles = mapOf(
+      "acc_wallet_evm" to WalletProfile(
+        accountId = "acc_wallet_evm",
+        connectorId = "walletconnect",
+        addresses = mapOf(
+          "ETH" to "0xWALLETETH",
+          "ARB" to "0xWALLETARB",
+        ),
+        gasFeeUsd = mapOf(
+          "ETH" to 2.5,
+          "ARB" to 0.5,
+        ),
+      ),
+    )
+
+    val priceQuotes = mapOf(
+      "binance" to mapOf(
+        "USDT" to 1.0,
+        "BTC" to 30000.0,
+      ),
+      "coinbase" to mapOf(
+        "USDT" to 1.01,
+        "BTC" to 30100.0,
+      ),
+    )
+
+    return FundingConfig(
+      tradingProfiles = tradingProfiles,
+      depositAddresses = depositAddresses,
+      walletProfiles = walletProfiles,
+      priceQuotes = priceQuotes,
+    )
+  }
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/funding/FundingServiceImpl.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/funding/FundingServiceImpl.kt
@@ -1,0 +1,312 @@
+package com.kevin.cryptotrader.data.funding
+
+import com.kevin.cryptotrader.contracts.Account
+import com.kevin.cryptotrader.contracts.AccountId
+import com.kevin.cryptotrader.contracts.CostBreakdown
+import com.kevin.cryptotrader.contracts.FundingService
+import com.kevin.cryptotrader.contracts.Kind
+import com.kevin.cryptotrader.contracts.PlanPrefs
+import com.kevin.cryptotrader.contracts.PlanSafetyCheck
+import com.kevin.cryptotrader.contracts.PlanStatus
+import com.kevin.cryptotrader.contracts.SafetyStatus
+import com.kevin.cryptotrader.contracts.TransferPlan
+import com.kevin.cryptotrader.contracts.TransferStep
+import com.kevin.cryptotrader.data.portfolio.AccountsRepository
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import java.util.UUID
+
+class FundingServiceImpl(
+  private val accountsRepository: AccountsRepository,
+  private val config: FundingConfig = FundingFixtures.default(),
+) : FundingService {
+  private val updates = MutableSharedFlow<PlanStatus>(extraBufferCapacity = 32)
+
+  override suspend fun planTransfer(
+    from: AccountId?,
+    to: AccountId,
+    asset: String,
+    amount: Double,
+    preferences: PlanPrefs,
+  ): TransferPlan {
+    require(amount > 0) { "Amount must be positive" }
+    val targetAccount = accountsRepository.getAccount(to)
+      ?: error("Target account $to not found")
+    val sourceAccount = from?.let { accountsRepository.getAccount(it) }
+
+    return if (sourceAccount == null) {
+      val quotes = estimateRoutes(asset, amount, to, preferences)
+      quotes.firstOrNull()?.plan ?: error("No viable funding route found for $asset → ${targetAccount.name}")
+    } else {
+      planMovement(sourceAccount, targetAccount, asset.uppercase(), amount)
+    }
+  }
+
+  override suspend fun execute(plan: TransferPlan): String {
+    val execId = "exec-${plan.id}-${System.currentTimeMillis()}"
+    plan.steps.forEachIndexed { idx, _ ->
+      updates.tryEmit(PlanStatus(planId = plan.id, stepIndex = idx, state = "STARTED"))
+      delay(25)
+      updates.tryEmit(PlanStatus(planId = plan.id, stepIndex = idx, state = "COMPLETED"))
+    }
+    updates.tryEmit(PlanStatus(planId = plan.id, stepIndex = plan.steps.lastIndex, state = "COMPLETED_PLAN"))
+    return execId
+  }
+
+  override fun track(executionId: String): Flow<PlanStatus> = updates.asSharedFlow()
+
+  data class PlanQuote(
+    val plan: TransferPlan,
+    val sourceAccountId: AccountId,
+    val venueId: String,
+  )
+
+  fun estimateRoutes(
+    asset: String,
+    amount: Double,
+    toAccountId: AccountId,
+    preferences: PlanPrefs = PlanPrefs(),
+  ): List<PlanQuote> {
+    val targetAccount = accountsRepository.getAccount(toAccountId)
+      ?: error("Target account $toAccountId not found")
+    val cexAccounts = accountsRepository.stream().value.filter { it.kind == Kind.CEX }
+    val preferred = preferences.preferExchange?.lowercase()
+    val candidates = if (preferred != null) {
+      cexAccounts.filter { it.venueId.equals(preferred, true) }
+    } else {
+      cexAccounts
+    }
+
+    val plans = candidates.mapNotNull { source ->
+      val profile = config.tradingProfileFor(source.venueId) ?: return@mapNotNull null
+      val price = config.quotePrice(source.venueId, asset) ?: return@mapNotNull null
+      val networkSelection = selectWithdrawalNetwork(source, targetAccount, asset, profile) ?: return@mapNotNull null
+      val address = resolveDestinationAddress(targetAccount, asset, networkSelection.network) ?: return@mapNotNull null
+      val notional = price * amount
+      val tradingFee = notional * profile.tradingFeeBps / 10_000.0
+      val withdrawalFee = networkSelection.fee.feeUsd
+      val networkFee = if (targetAccount.kind == Kind.WALLET) {
+        config.walletProfile(targetAccount.id)?.gasFeeUsd?.get(networkSelection.network.uppercase()) ?: 0.0
+      } else {
+        0.0
+      }
+      val cost = CostBreakdown(
+        notionalUsd = notional,
+        tradingFeesUsd = tradingFee,
+        withdrawalFeesUsd = withdrawalFee,
+        networkFeesUsd = networkFee,
+      )
+      val totalFeesBps = if (cost.notionalUsd > 0) (cost.totalFeesUsd / cost.notionalUsd) * 10_000 else 0.0
+      val maxFeesBps = preferences.maxFeesBps
+      if (maxFeesBps != null && totalFeesBps > maxFeesBps) return@mapNotNull null
+      val safety = buildSafetyChecks(
+        allowlisted = address.whitelisted,
+        twoTap = true,
+      )
+      val plan = TransferPlan(
+        id = UUID.randomUUID().toString(),
+        steps = listOf(
+          TransferStep.BuyOnExchange(exchangeId = source.venueId, symbol = "$asset/USDT", qty = amount),
+          TransferStep.Withdraw(
+            exchangeId = source.venueId,
+            asset = asset.uppercase(),
+            network = networkSelection.network,
+            address = address.address,
+            amount = amount,
+            memo = address.memo,
+          ),
+        ),
+        totalCostUsd = cost.totalCostUsd,
+        etaSeconds = networkSelection.fee.etaSeconds + 60,
+        costBreakdown = cost,
+        safetyChecks = safety,
+      )
+      PlanQuote(plan = plan, sourceAccountId = source.id, venueId = source.venueId)
+    }
+
+    return plans.sortedBy { it.plan.totalCostUsd }
+  }
+
+  private fun planMovement(
+    from: Account,
+    to: Account,
+    asset: String,
+    amount: Double,
+  ): TransferPlan {
+    val profile = config.tradingProfileFor(from.venueId)
+    return when {
+      from.kind == Kind.CEX && to.kind == Kind.CEX && from.venueId.equals(to.venueId, true) -> {
+        val cost = CostBreakdown(notionalUsd = 0.0)
+        TransferPlan(
+          id = UUID.randomUUID().toString(),
+          steps = listOf(
+            TransferStep.TransferInternal(
+              accountFrom = from.id,
+              accountTo = to.id,
+              asset = asset,
+              amount = amount,
+            ),
+          ),
+          totalCostUsd = cost.totalCostUsd,
+          etaSeconds = 120,
+          costBreakdown = cost,
+          safetyChecks = listOf(
+            PlanSafetyCheck(
+              id = "internal_transfer_review",
+              description = "Review internal transfer between ${from.name} accounts",
+              status = SafetyStatus.PASSED,
+              blocking = false,
+            ),
+          ),
+        )
+      }
+
+      from.kind == Kind.CEX -> {
+        requireNotNull(profile) { "No trading profile for ${from.venueId}" }
+        val networkSelection = selectWithdrawalNetwork(from, to, asset, profile)
+          ?: error("No shared network between ${from.name} and ${to.name} for $asset")
+        ensureMinAmount(amount, networkSelection.fee)
+        val destination = resolveDestinationAddress(to, asset, networkSelection.network)
+          ?: error("No destination address for ${to.name} on ${networkSelection.network}")
+        val networkFee = if (to.kind == Kind.WALLET) {
+          config.walletProfile(to.id)?.gasFeeUsd?.get(networkSelection.network.uppercase()) ?: 0.0
+        } else {
+          0.0
+        }
+        val cost = CostBreakdown(
+          notionalUsd = 0.0,
+          tradingFeesUsd = 0.0,
+          withdrawalFeesUsd = networkSelection.fee.feeUsd,
+          networkFeesUsd = networkFee,
+        )
+        TransferPlan(
+          id = UUID.randomUUID().toString(),
+          steps = listOf(
+            TransferStep.Withdraw(
+              exchangeId = from.venueId,
+              asset = asset,
+              network = networkSelection.network,
+              address = destination.address,
+              amount = amount,
+              memo = destination.memo,
+            ),
+          ),
+          totalCostUsd = cost.totalCostUsd,
+          etaSeconds = networkSelection.fee.etaSeconds,
+          costBreakdown = cost,
+          safetyChecks = buildSafetyChecks(destination.whitelisted, twoTap = true),
+        )
+      }
+
+      from.kind == Kind.WALLET -> {
+        val walletProfile = config.walletProfile(from.id)
+          ?: error("Wallet profile missing for ${from.name}")
+        val network = pickWalletNetwork(from, to)
+          ?: error("Wallet ${from.name} does not support network to reach ${to.name}")
+        val destination = resolveDestinationAddress(to, asset, network)
+          ?: error("Destination address unavailable for ${to.name} on $network")
+        val gasFee = walletProfile.gasFeeUsd[network.uppercase()] ?: 0.0
+        val cost = CostBreakdown(
+          notionalUsd = 0.0,
+          tradingFeesUsd = 0.0,
+          withdrawalFeesUsd = 0.0,
+          networkFeesUsd = gasFee,
+        )
+        TransferPlan(
+          id = UUID.randomUUID().toString(),
+          steps = listOf(
+            TransferStep.WalletTransfer(
+              walletId = from.id,
+              toAddress = destination.address,
+              asset = asset,
+              network = network,
+              amount = amount,
+              connector = walletProfile.connectorId,
+              memo = destination.memo,
+            ),
+          ),
+          totalCostUsd = cost.totalCostUsd,
+          etaSeconds = 180,
+          costBreakdown = cost,
+          safetyChecks = listOf(
+            PlanSafetyCheck(
+              id = "wallet_confirm",
+              description = "Approve transaction in connected wallet",
+              status = SafetyStatus.PENDING,
+              blocking = true,
+            ),
+          ),
+        )
+      }
+
+      else -> error("Unsupported funding route from ${from.kind} to ${to.kind}")
+    }
+  }
+
+  private fun pickWalletNetwork(from: Account, to: Account): String? {
+    val fromNetworks = from.networks.map { it.uppercase() }.toSet()
+    val toNetworks = to.networks.map { it.uppercase() }.toSet()
+    val shared = fromNetworks.intersect(toNetworks)
+    if (shared.isEmpty()) return null
+    return shared.first()
+  }
+
+  private fun selectWithdrawalNetwork(
+    from: Account,
+    to: Account,
+    asset: String,
+    profile: TradingProfile,
+  ): NetworkSelection? {
+    val fromNetworks = from.networks.map { it.uppercase() }.toSet()
+    val toNetworks = to.networks.map { it.uppercase() }.toSet()
+    val shared = fromNetworks.intersect(toNetworks)
+    val candidates = profile.withdrawalFees[asset.uppercase()] ?: return null
+    return candidates
+      .filter { fee -> shared.contains(fee.network.uppercase()) }
+      .minByOrNull { it.feeUsd }
+      ?.let { fee -> NetworkSelection(network = fee.network.uppercase(), fee = fee) }
+  }
+
+  private fun resolveDestinationAddress(account: Account, asset: String, network: String): DepositAddress? {
+    return when (account.kind) {
+      Kind.CEX -> config.depositAddress(account.id, asset, network)
+      Kind.WALLET -> {
+        val wallet = config.walletProfile(account.id) ?: return null
+        val address = wallet.addresses[network.uppercase()] ?: return null
+        DepositAddress(address = address, memo = null, whitelisted = true)
+      }
+    }
+  }
+
+  private fun buildSafetyChecks(allowlisted: Boolean, twoTap: Boolean): List<PlanSafetyCheck> {
+    val checks = mutableListOf<PlanSafetyCheck>()
+    checks += PlanSafetyCheck(
+      id = "allowlist",
+      description = if (allowlisted) "Destination address is allow-listed" else "Destination address requires review",
+      status = if (allowlisted) SafetyStatus.PASSED else SafetyStatus.WARNING,
+      blocking = !allowlisted,
+    )
+    if (twoTap) {
+      checks += PlanSafetyCheck(
+        id = "two_tap_confirm",
+        description = "Two-step confirmation required",
+        status = SafetyStatus.PENDING,
+        blocking = false,
+      )
+    }
+    return checks
+  }
+
+  private fun ensureMinAmount(amount: Double, fee: WithdrawalNetworkFee) {
+    require(amount >= fee.minAmount) {
+      "Amount $amount is below minimum withdrawal ${fee.minAmount} for network ${fee.network}"
+    }
+  }
+
+  private data class NetworkSelection(
+    val network: String,
+    val fee: WithdrawalNetworkFee,
+  )
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/funding/FundingServiceMock.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/funding/FundingServiceMock.kt
@@ -16,7 +16,28 @@ class FundingServiceMock : FundingService {
     } else {
       steps += TransferStep.TransferInternal(accountFrom = from, accountTo = to, asset = asset, amount = amount)
     }
-    return TransferPlan(id = "plan-$asset-$amount", steps = steps, totalCostUsd = amount * 0.001, etaSeconds = 120)
+    val cost = CostBreakdown(
+      notionalUsd = 0.0,
+      tradingFeesUsd = 0.0,
+      withdrawalFeesUsd = amount * 0.001,
+      networkFeesUsd = 0.0,
+    )
+    val safety = listOf(
+      PlanSafetyCheck(
+        id = "mock_two_tap",
+        description = "Confirm mock transfer",
+        status = SafetyStatus.PENDING,
+        blocking = false,
+      )
+    )
+    return TransferPlan(
+      id = "plan-$asset-$amount",
+      steps = steps,
+      totalCostUsd = cost.totalCostUsd,
+      etaSeconds = 120,
+      costBreakdown = cost,
+      safetyChecks = safety,
+    )
   }
 
   override suspend fun execute(plan: TransferPlan): String {

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/portfolio/PortfolioRepositories.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/portfolio/PortfolioRepositories.kt
@@ -1,0 +1,223 @@
+package com.kevin.cryptotrader.data.portfolio
+
+import com.kevin.cryptotrader.contracts.Account
+import com.kevin.cryptotrader.contracts.AccountId
+import com.kevin.cryptotrader.contracts.Holding
+import com.kevin.cryptotrader.contracts.Kind
+import com.kevin.cryptotrader.contracts.Position
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+
+class AccountsRepository(
+  initialAccounts: List<Account> = FixturesLoader.loadAccounts(),
+) {
+  private val accounts = MutableStateFlow(initialAccounts.sortedBy { it.name })
+
+  fun stream(): StateFlow<List<Account>> = accounts.asStateFlow()
+
+  fun getAccount(id: AccountId): Account? = accounts.value.firstOrNull { it.id == id }
+
+  fun upsert(account: Account) {
+    accounts.update { current ->
+      val existing = current.indexOfFirst { it.id == account.id }
+      if (existing >= 0) {
+        current.toMutableList().also { list ->
+          list[existing] = account
+          list.sortBy { it.name }
+          return@update list
+        }
+      }
+      (current + account).sortedBy { it.name }
+    }
+  }
+
+  fun remove(accountId: AccountId) {
+    accounts.update { current -> current.filterNot { it.id == accountId } }
+  }
+}
+
+class BalancesRepository {
+  private val holdings = MutableStateFlow<Map<AccountId, List<Holding>>>(emptyMap())
+
+  fun stream(): StateFlow<Map<AccountId, List<Holding>>> = holdings.asStateFlow()
+
+  fun update(accountId: AccountId, newHoldings: List<Holding>) {
+    holdings.update { current ->
+      val sanitized = newHoldings.map { holding ->
+        holding.copy(network = holding.network?.uppercase())
+      }
+      current + (accountId to sanitized)
+    }
+  }
+
+  fun getHoldings(accountId: AccountId): List<Holding> = holdings.value[accountId] ?: emptyList()
+}
+
+class PositionsRepository {
+  private val positions = MutableStateFlow<Map<AccountId, List<Position>>>(emptyMap())
+
+  fun stream(): StateFlow<Map<AccountId, List<Position>>> = positions.asStateFlow()
+
+  fun update(accountId: AccountId, newPositions: List<Position>) {
+    positions.update { current -> current + (accountId to newPositions) }
+  }
+
+  fun getPositions(accountId: AccountId): List<Position> = positions.value[accountId] ?: emptyList()
+}
+
+data class AggregatedHolding(
+  val asset: String,
+  val network: String?,
+  val totalFree: Double,
+  val totalLocked: Double,
+  val valuationUsd: Double,
+  val breakdown: List<HoldingBreakdown>,
+)
+
+data class HoldingBreakdown(
+  val accountId: AccountId,
+  val accountKind: Kind,
+  val accountName: String,
+  val free: Double,
+  val locked: Double,
+  val valuationUsd: Double,
+  val network: String?,
+)
+
+data class AggregatedPosition(
+  val symbol: String,
+  val netQty: Double,
+  val avgPrice: Double,
+  val realizedPnl: Double,
+  val unrealizedPnl: Double,
+  val breakdown: List<PositionBreakdown>,
+)
+
+data class PositionBreakdown(
+  val accountId: AccountId,
+  val accountKind: Kind,
+  val accountName: String,
+  val qty: Double,
+  val avgPrice: Double,
+  val realizedPnl: Double,
+  val unrealizedPnl: Double,
+)
+
+class PortfolioRepository(
+  private val accountsRepository: AccountsRepository,
+  private val balancesRepository: BalancesRepository,
+  private val positionsRepository: PositionsRepository,
+) {
+
+  val aggregatedHoldings: Flow<List<AggregatedHolding>> = combine(
+    accountsRepository.stream(),
+    balancesRepository.stream(),
+  ) { accounts, holdings ->
+    val byAsset = holdings.values.flatten().groupBy { it.asset.uppercase() to (it.network?.uppercase()) }
+    byAsset.map { (key, items) ->
+      val (asset, network) = key
+      aggregateHolding(asset, network, items, accounts)
+    }.sortedWith(compareBy<AggregatedHolding> { it.asset }.thenBy { it.network ?: "" })
+  }
+
+  val aggregatedPositions: Flow<List<AggregatedPosition>> = combine(
+    accountsRepository.stream(),
+    positionsRepository.stream(),
+  ) { accounts, positions ->
+    val bySymbol = positions.values.flatten().groupBy { it.symbol.uppercase() }
+    bySymbol.map { (symbol, items) ->
+      aggregatePosition(symbol, items, accounts)
+    }.sortedBy { it.symbol }
+  }
+
+  fun portfolioValue(): Double {
+    return balancesRepository.stream().value.values.flatten().sumOf { it.valuationUsd }
+  }
+
+  fun getNetHoldings(asset: String, network: String? = null): AggregatedHolding? {
+    val accounts = accountsRepository.stream().value
+    val items = balancesRepository.stream().value.values
+      .flatten()
+      .filter { it.asset.equals(asset, true) && networkMatches(it.network, network) }
+    if (items.isEmpty()) return null
+    return aggregateHolding(asset.uppercase(), network?.uppercase(), items, accounts)
+  }
+
+  fun getNetExposure(symbol: String): AggregatedPosition? {
+    val accounts = accountsRepository.stream().value
+    val positions = positionsRepository.stream().value.values.flatten().filter { it.symbol.equals(symbol, true) }
+    if (positions.isEmpty()) return null
+    return aggregatePosition(symbol.uppercase(), positions, accounts)
+  }
+
+  private fun aggregateHolding(
+    asset: String,
+    network: String?,
+    holdings: List<Holding>,
+    accounts: List<Account>,
+  ): AggregatedHolding {
+    val breakdown = holdings.map { holding ->
+      val account = accounts.firstOrNull { it.id == holding.accountId }
+      HoldingBreakdown(
+        accountId = holding.accountId,
+        accountKind = account?.kind ?: Kind.CEX,
+        accountName = account?.name ?: holding.accountId,
+        free = holding.free,
+        locked = holding.locked,
+        valuationUsd = holding.valuationUsd,
+        network = holding.network,
+      )
+    }
+    val totalFree = holdings.sumOf { it.free }
+    val totalLocked = holdings.sumOf { it.locked }
+    val valuationUsd = holdings.sumOf { it.valuationUsd }
+    return AggregatedHolding(
+      asset = asset,
+      network = network,
+      totalFree = totalFree,
+      totalLocked = totalLocked,
+      valuationUsd = valuationUsd,
+      breakdown = breakdown,
+    )
+  }
+
+  private fun aggregatePosition(
+    symbol: String,
+    positions: List<Position>,
+    accounts: List<Account>,
+  ): AggregatedPosition {
+    val breakdown = positions.map { position ->
+      val account = accounts.firstOrNull { it.id == position.accountId }
+      PositionBreakdown(
+        accountId = position.accountId,
+        accountKind = account?.kind ?: Kind.CEX,
+        accountName = account?.name ?: position.accountId,
+        qty = position.qty,
+        avgPrice = position.avgPrice,
+        realizedPnl = position.realizedPnl,
+        unrealizedPnl = position.unrealizedPnl,
+      )
+    }
+    val netQty = positions.sumOf { it.qty }
+    val weightedAvgPrice = if (netQty == 0.0) 0.0 else positions.sumOf { it.qty * it.avgPrice } / netQty
+    val realized = positions.sumOf { it.realizedPnl }
+    val unrealized = positions.sumOf { it.unrealizedPnl }
+    return AggregatedPosition(
+      symbol = symbol,
+      netQty = netQty,
+      avgPrice = weightedAvgPrice,
+      realizedPnl = realized,
+      unrealizedPnl = unrealized,
+      breakdown = breakdown,
+    )
+  }
+
+  private fun networkMatches(source: String?, target: String?): Boolean {
+    if (target == null) return true
+    return source?.equals(target, ignoreCase = true) == true
+  }
+}

--- a/data/src/main/kotlin/com/kevin/cryptotrader/data/portfolio/PortfolioServiceMock.kt
+++ b/data/src/main/kotlin/com/kevin/cryptotrader/data/portfolio/PortfolioServiceMock.kt
@@ -17,7 +17,6 @@ class PortfolioServiceMock : PortfolioService {
   override fun positions(): Flow<List<Position>> = positionsFlow.asStateFlow()
 
   override suspend fun acquire(asset: String, amount: Double, target: AccountId?): TransferPlan {
-    val to = target ?: accountsFlow.value.firstOrNull()?.id ?: "acc_unknown"
     return TransferPlan(
       id = "tp-$asset-$amount",
       steps = listOf(
@@ -25,6 +24,20 @@ class PortfolioServiceMock : PortfolioService {
       ),
       totalCostUsd = amount * 1.0,
       etaSeconds = 60,
+      costBreakdown = CostBreakdown(
+        notionalUsd = amount * 1.0,
+        tradingFeesUsd = 0.0,
+        withdrawalFeesUsd = 0.0,
+        networkFeesUsd = 0.0,
+      ),
+      safetyChecks = listOf(
+        PlanSafetyCheck(
+          id = "mock_preview",
+          description = "Preview only",
+          status = SafetyStatus.WARNING,
+          blocking = false,
+        )
+      ),
     )
   }
 }

--- a/data/src/test/kotlin/com/kevin/cryptotrader/data/funding/FundingServiceImplTest.kt
+++ b/data/src/test/kotlin/com/kevin/cryptotrader/data/funding/FundingServiceImplTest.kt
@@ -1,0 +1,102 @@
+package com.kevin.cryptotrader.data.funding
+
+import com.kevin.cryptotrader.contracts.PlanPrefs
+import com.kevin.cryptotrader.contracts.TransferStep
+import com.kevin.cryptotrader.data.portfolio.AccountsRepository
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class FundingServiceImplTest {
+  private val accountsRepository = AccountsRepository()
+  private val funding = FundingServiceImpl(accountsRepository)
+
+  @Test
+  fun plansWithdrawFromCexToWalletWithSafetyChecks() = runBlocking {
+    val plan = funding.planTransfer(
+      from = "acc_binance",
+      to = "acc_wallet_evm",
+      asset = "USDT",
+      amount = 100.0,
+      preferences = PlanPrefs(),
+    )
+
+    assertEquals(1, plan.steps.size)
+    val withdraw = plan.steps.first()
+    assertIs<TransferStep.Withdraw>(withdraw)
+    assertEquals("ETH", withdraw.network)
+    assertTrue(plan.totalCostUsd > 0)
+    assertEquals(plan.costBreakdown.totalCostUsd, plan.totalCostUsd, 1e-6)
+    assertTrue(plan.safetyChecks.any { it.id == "two_tap_confirm" })
+    assertTrue(plan.safetyChecks.any { it.id == "allowlist" })
+  }
+
+  @Test
+  fun estimatesRoutesAndChoosesCheapest() {
+    val quotes = funding.estimateRoutes(asset = "USDT", amount = 100.0, toAccountId = "acc_wallet_evm")
+    assertTrue(quotes.size >= 1)
+    val cheapest = quotes.first()
+    assertTrue(quotes.zipWithNext().all { (a, b) -> a.plan.totalCostUsd <= b.plan.totalCostUsd })
+    assertEquals("acc_binance", cheapest.sourceAccountId)
+    assertEquals("binance", cheapest.venueId)
+    assertTrue(cheapest.plan.steps.first() is TransferStep.BuyOnExchange)
+  }
+
+  @Test
+  fun enforcesFeePreferences() {
+    val quotes = funding.estimateRoutes(
+      asset = "USDT",
+      amount = 100.0,
+      toAccountId = "acc_wallet_evm",
+      preferences = PlanPrefs(maxFeesBps = 5),
+    )
+    // 5 bps is stricter than the default fees; expect no quotes
+    assertTrue(quotes.isEmpty())
+  }
+
+  @Test
+  fun plansWalletToExchangeTransfer() = runBlocking {
+    val plan = funding.planTransfer(
+      from = "acc_wallet_evm",
+      to = "acc_coinbase",
+      asset = "USDT",
+      amount = 50.0,
+      preferences = PlanPrefs(),
+    )
+
+    assertEquals(1, plan.steps.size)
+    val step = plan.steps.first()
+    assertIs<TransferStep.WalletTransfer>(step)
+    assertEquals("ETH", step.network)
+    assertEquals("walletconnect", step.connector)
+  }
+
+  @Test
+  fun plansInternalTransferForSameVenue() = runBlocking {
+    val internalAccount = com.kevin.cryptotrader.contracts.Account(
+      id = "acc_binance_funding",
+      kind = com.kevin.cryptotrader.contracts.Kind.CEX,
+      name = "Binance Funding",
+      venueId = "binance",
+      networks = listOf("ETH", "TRX"),
+    )
+    accountsRepository.upsert(internalAccount)
+
+    val plan = funding.planTransfer(
+      from = "acc_binance",
+      to = "acc_binance_funding",
+      asset = "USDT",
+      amount = 25.0,
+      preferences = PlanPrefs(),
+    )
+
+    assertEquals(1, plan.steps.size)
+    val internal = plan.steps.first()
+    assertIs<TransferStep.TransferInternal>(internal)
+    assertEquals("acc_binance", internal.accountFrom)
+    assertEquals("acc_binance_funding", internal.accountTo)
+    assertEquals(0.0, plan.totalCostUsd, 1e-6)
+  }
+}

--- a/data/src/test/kotlin/com/kevin/cryptotrader/data/portfolio/PortfolioRepositoryTest.kt
+++ b/data/src/test/kotlin/com/kevin/cryptotrader/data/portfolio/PortfolioRepositoryTest.kt
@@ -1,0 +1,88 @@
+package com.kevin.cryptotrader.data.portfolio
+
+import com.kevin.cryptotrader.contracts.Account
+import com.kevin.cryptotrader.contracts.Holding
+import com.kevin.cryptotrader.contracts.Kind
+import com.kevin.cryptotrader.contracts.Position
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PortfolioRepositoryTest {
+  private val accounts = listOf(
+    Account(id = "acc_binance", kind = Kind.CEX, name = "Binance", venueId = "binance", networks = listOf("ETH", "TRX")),
+    Account(id = "acc_coinbase", kind = Kind.CEX, name = "Coinbase", venueId = "coinbase", networks = listOf("ETH")),
+    Account(id = "acc_wallet", kind = Kind.WALLET, name = "Wallet", venueId = "wallet:evm:0xabc", networks = listOf("ETH", "ARB")),
+  )
+  private val accountsRepo = AccountsRepository(accounts)
+  private val balancesRepo = BalancesRepository()
+  private val positionsRepo = PositionsRepository()
+  private val portfolio = PortfolioRepository(accountsRepo, balancesRepo, positionsRepo)
+
+  @Test
+  fun aggregatesHoldingsAcrossAccounts() = runBlocking {
+    balancesRepo.update(
+      accountId = "acc_binance",
+      newHoldings = listOf(
+        Holding(accountId = "acc_binance", asset = "USDT", network = "ETH", free = 500.0, locked = 0.0, valuationUsd = 500.0),
+        Holding(accountId = "acc_binance", asset = "BTC", network = null, free = 0.5, locked = 0.0, valuationUsd = 15000.0),
+      ),
+    )
+    balancesRepo.update(
+      accountId = "acc_coinbase",
+      newHoldings = listOf(
+        Holding(accountId = "acc_coinbase", asset = "USDT", network = "ETH", free = 200.0, locked = 0.0, valuationUsd = 200.0),
+      ),
+    )
+    balancesRepo.update(
+      accountId = "acc_wallet",
+      newHoldings = listOf(
+        Holding(accountId = "acc_wallet", asset = "USDT", network = "ETH", free = 100.0, locked = 0.0, valuationUsd = 100.0),
+      ),
+    )
+
+    val holdings = portfolio.aggregatedHoldings.first()
+    val usdtHolding = holdings.first { it.asset == "USDT" }
+    assertEquals(800.0, usdtHolding.totalFree, 1e-6)
+    assertEquals(800.0, usdtHolding.valuationUsd, 1e-6)
+    assertEquals(3, usdtHolding.breakdown.size)
+    assertEquals("ETH", usdtHolding.network)
+
+    val portfolioValue = portfolio.portfolioValue()
+    assertEquals(15800.0, portfolioValue, 1e-6)
+
+    val netHoldings = portfolio.getNetHoldings("USDT")
+    assertNotNull(netHoldings)
+    assertEquals(800.0, netHoldings.totalFree, 1e-6)
+  }
+
+  @Test
+  fun aggregatesPositions() = runBlocking {
+    positionsRepo.update(
+      accountId = "acc_binance",
+      newPositions = listOf(
+        Position(accountId = "acc_binance", symbol = "BTCUSDT", qty = 0.4, avgPrice = 28000.0, realizedPnl = 1000.0, unrealizedPnl = 500.0),
+      ),
+    )
+    positionsRepo.update(
+      accountId = "acc_coinbase",
+      newPositions = listOf(
+        Position(accountId = "acc_coinbase", symbol = "BTCUSDT", qty = 0.3, avgPrice = 29000.0, realizedPnl = 200.0, unrealizedPnl = 100.0),
+      ),
+    )
+
+    val positions = portfolio.aggregatedPositions.first()
+    assertEquals(1, positions.size)
+    val btc = positions.first()
+    assertEquals("BTCUSDT", btc.symbol)
+    assertEquals(0.7, btc.netQty, 1e-6)
+    assertTrue(btc.avgPrice in 28000.0..29000.0)
+
+    val exposure = portfolio.getNetExposure("BTCUSDT")
+    assertNotNull(exposure)
+    assertEquals(0.7, exposure.netQty, 1e-6)
+  }
+}


### PR DESCRIPTION
## Summary
- extend transfer plan domain objects with cost breakdowns, safety checks, and wallet transfer steps
- add funding configuration and FundingService implementation that quotes multi-hop plans across CEX and wallet connectors
- build portfolio repositories aggregating accounts, balances, and positions for Buy Anywhere estimates plus supporting tests

## Testing
- ./gradlew data:test

------
https://chatgpt.com/codex/tasks/task_e_68e17abf855083219173e6d7868f7938