### PR TITLE
Implement execution pipeline with paper and live brokers

### DIFF
--- a/livebroker/build.gradle.kts
+++ b/livebroker/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.serialization")
+}
+
+kotlin { jvmToolchain(17) }
+
+dependencies {
+    implementation(project(":contracts"))
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+}
+
+tasks.test { useJUnitPlatform() }

--- a/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/ExchangeAdapter.kt
+++ b/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/ExchangeAdapter.kt
@@ -1,0 +1,20 @@
+package com.kevin.cryptotrader.live
+
+import com.kevin.cryptotrader.contracts.AccountSnapshot
+import com.kevin.cryptotrader.contracts.BrokerEvent
+import com.kevin.cryptotrader.contracts.Order
+import kotlinx.coroutines.flow.Flow
+
+interface ExchangeAdapter {
+    suspend fun place(order: Order): String
+    suspend fun cancel(orderId: String): Boolean
+    fun streamEvents(accounts: Set<String>): Flow<BrokerEvent>
+    suspend fun account(): AccountSnapshot
+}
+
+class LiveBroker(private val adapter: ExchangeAdapter) : com.kevin.cryptotrader.contracts.Broker {
+    override suspend fun place(order: Order): String = adapter.place(order)
+    override suspend fun cancel(clientOrderId: String): Boolean = adapter.cancel(clientOrderId)
+    override fun streamEvents(accounts: Set<String>): Flow<BrokerEvent> = adapter.streamEvents(accounts)
+    override suspend fun account(): AccountSnapshot = adapter.account()
+}

--- a/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/RestExecutor.kt
+++ b/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/RestExecutor.kt
@@ -1,0 +1,77 @@
+package com.kevin.cryptotrader.live
+
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import kotlinx.coroutines.future.await
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+/** Represents a generic REST request that can be executed against an exchange API. */
+data class RestRequest(
+    val method: String,
+    val path: String,
+    val query: Map<String, String> = emptyMap(),
+    val body: String? = null,
+    val headers: Map<String, String> = emptyMap(),
+    val contentType: String? = null,
+    val timeout: Duration = Duration.ofSeconds(10)
+)
+
+interface RestExecutor {
+    suspend fun execute(request: RestRequest): JsonObject
+}
+
+class RestException(val statusCode: Int, val payload: String) : Exception("HTTP $statusCode: $payload")
+
+class HttpClientRestExecutor(
+    private val baseUrl: String,
+    private val client: HttpClient = HttpClient.newBuilder().build(),
+    private val json: Json = Json { ignoreUnknownKeys = true }
+) : RestExecutor {
+    override suspend fun execute(request: RestRequest): JsonObject {
+        val uri = buildUri(request)
+        val httpRequest = buildRequest(uri, request)
+        val response = client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString()).await()
+        if (response.statusCode() >= 400) {
+            throw RestException(response.statusCode(), response.body())
+        }
+        val element = json.parseToJsonElement(response.body())
+        return element.jsonObject
+    }
+
+    private fun buildUri(request: RestRequest): URI {
+        val base = if (request.path.startsWith("http")) {
+            request.path
+        } else {
+            baseUrl.trimEnd('/') + request.path
+        }
+        if (request.query.isEmpty()) {
+            return URI.create(base)
+        }
+        val queryString = request.query.entries.joinToString("&") { (k, v) ->
+            "${encode(k)}=${encode(v)}"
+        }
+        return URI.create("$base?$queryString")
+    }
+
+    private fun buildRequest(uri: URI, request: RestRequest): HttpRequest {
+        val builder = HttpRequest.newBuilder()
+            .uri(uri)
+            .timeout(request.timeout)
+        request.headers.forEach { (key, value) -> builder.header(key, value) }
+        request.contentType?.let { builder.header("Content-Type", it) }
+        val method = request.method.uppercase()
+        val bodyPublisher = request.body?.let { HttpRequest.BodyPublishers.ofString(it) }
+            ?: HttpRequest.BodyPublishers.noBody()
+        return builder.method(method, bodyPublisher).build()
+    }
+
+    private fun encode(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8)
+}

--- a/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/UserEventSource.kt
+++ b/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/UserEventSource.kt
@@ -1,0 +1,8 @@
+package com.kevin.cryptotrader.live
+
+import com.kevin.cryptotrader.contracts.BrokerEvent
+import kotlinx.coroutines.flow.Flow
+
+fun interface UserEventSource {
+    fun stream(accounts: Set<String>): Flow<BrokerEvent>
+}

--- a/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/binance/BinanceExchangeAdapter.kt
+++ b/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/binance/BinanceExchangeAdapter.kt
@@ -1,0 +1,160 @@
+package com.kevin.cryptotrader.live.binance
+
+import com.kevin.cryptotrader.contracts.AccountSnapshot
+import com.kevin.cryptotrader.contracts.BrokerEvent
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.TIF
+import com.kevin.cryptotrader.live.ExchangeAdapter
+import com.kevin.cryptotrader.live.RestExecutor
+import com.kevin.cryptotrader.live.RestRequest
+import com.kevin.cryptotrader.live.UserEventSource
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.nio.charset.StandardCharsets
+import java.time.Clock
+import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class BinanceExchangeAdapter(
+    private val apiKey: String,
+    private val secretKey: String,
+    private val rest: RestExecutor,
+    private val events: UserEventSource,
+    private val clock: Clock = Clock.systemUTC(),
+    private val recvWindowMs: Long = 5_000
+) : ExchangeAdapter {
+    private val orderToSymbol = ConcurrentHashMap<String, String>()
+
+    override suspend fun place(order: Order): String {
+        val params = linkedMapOf(
+            "symbol" to order.symbol,
+            "side" to order.side.name,
+            "type" to order.type.name,
+            "timestamp" to clock.millis().toString(),
+            "recvWindow" to recvWindowMs.toString()
+        )
+        if (order.clientOrderId.isNotEmpty()) {
+            params["newClientOrderId"] = order.clientOrderId
+        }
+        when (order.type) {
+            OrderType.MARKET -> params["quantity"] = format(order.qty)
+            OrderType.LIMIT -> {
+                params["quantity"] = format(order.qty)
+                params["price"] = format(order.price ?: error("Limit order requires price"))
+                params["timeInForce"] = mapTif(order.tif)
+            }
+            OrderType.STOP, OrderType.STOP_LIMIT -> {
+                params["quantity"] = format(order.qty)
+                params["stopPrice"] = format(order.stopPrice ?: error("Stop price required"))
+                if (order.type == OrderType.STOP_LIMIT) {
+                    params["price"] = format(order.price ?: error("Stop limit requires limit price"))
+                    params["timeInForce"] = mapTif(order.tif)
+                }
+                params["type"] = if (order.type == OrderType.STOP) "STOP_LOSS" else "STOP_LOSS_LIMIT"
+            }
+        }
+        sign(params)
+        val response = rest.execute(
+            RestRequest(
+                method = "POST",
+                path = "/api/v3/order",
+                query = params,
+                headers = mapOf("X-MBX-APIKEY" to apiKey)
+            )
+        )
+        val orderId = response["clientOrderId"]?.jsonPrimitive?.content
+            ?: response["orderId"]?.jsonPrimitive?.content
+            ?: order.clientOrderId.ifEmpty { error("Binance response missing orderId") }
+        orderToSymbol[orderId] = order.symbol
+        return orderId
+    }
+
+    override suspend fun cancel(orderId: String): Boolean {
+        val symbol = orderToSymbol[orderId] ?: return false
+        val params = linkedMapOf(
+            "symbol" to symbol,
+            "origClientOrderId" to orderId,
+            "timestamp" to clock.millis().toString(),
+            "recvWindow" to recvWindowMs.toString()
+        )
+        sign(params)
+        val response = rest.execute(
+            RestRequest(
+                method = "DELETE",
+                path = "/api/v3/order",
+                query = params,
+                headers = mapOf("X-MBX-APIKEY" to apiKey)
+            )
+        )
+        val status = response["status"]?.jsonPrimitive?.content
+        val canceled = status == null || status == "CANCELED"
+        if (canceled) {
+            orderToSymbol.remove(orderId)
+        }
+        return canceled
+    }
+
+    override fun streamEvents(accounts: Set<String>): Flow<BrokerEvent> = events.stream(accounts)
+
+    override suspend fun account(): AccountSnapshot {
+        val params = linkedMapOf(
+            "timestamp" to clock.millis().toString(),
+            "recvWindow" to recvWindowMs.toString()
+        )
+        sign(params)
+        val response = rest.execute(
+            RestRequest(
+                method = "GET",
+                path = "/api/v3/account",
+                query = params,
+                headers = mapOf("X-MBX-APIKEY" to apiKey)
+            )
+        )
+        val balances = parseBalances(response)
+        val equity = balances.filterKeys { it in STABLE_COINS }.values.sum()
+        return AccountSnapshot(equity, balances)
+    }
+
+    private fun parseBalances(response: JsonObject): Map<String, Double> {
+        val balancesNode = response["balances"] ?: return emptyMap()
+        val array = balancesNode.jsonArray
+        return array.associate { element ->
+            val obj = element.jsonObject
+            val asset = obj["asset"]!!.jsonPrimitive.content
+            val free = obj["free"]!!.jsonPrimitive.content.toDouble()
+            val locked = obj["locked"]?.jsonPrimitive?.content?.toDouble() ?: 0.0
+            asset to (free + locked)
+        }.filterValues { it > 0.0 }
+    }
+
+    private fun mapTif(tif: TIF): String = when (tif) {
+        TIF.GTC, TIF.DAY -> "GTC"
+        TIF.IOC -> "IOC"
+        TIF.FOK -> "FOK"
+    }
+
+    private fun sign(params: LinkedHashMap<String, String>) {
+        val canonical = params.entries.joinToString("&") { "${it.key}=${it.value}" }
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secretKey.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
+        val signature = mac.doFinal(canonical.toByteArray(StandardCharsets.UTF_8)).joinToString("") { byte ->
+            "%02x".format(byte)
+        }
+        params["signature"] = signature
+    }
+
+    private fun format(value: Double): String =
+        BigDecimal.valueOf(value).setScale(SCALE, RoundingMode.DOWN).stripTrailingZeros().toPlainString()
+
+    companion object {
+        private val STABLE_COINS = setOf("USDT", "USDC", "BUSD", "TUSD", "USD")
+        private const val SCALE = 12
+    }
+}

--- a/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/coinbase/CoinbaseExchangeAdapter.kt
+++ b/livebroker/src/main/kotlin/com/kevin/cryptotrader/live/coinbase/CoinbaseExchangeAdapter.kt
@@ -1,0 +1,184 @@
+package com.kevin.cryptotrader.live.coinbase
+
+import com.kevin.cryptotrader.contracts.AccountSnapshot
+import com.kevin.cryptotrader.contracts.BrokerEvent
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.TIF
+import com.kevin.cryptotrader.live.ExchangeAdapter
+import com.kevin.cryptotrader.live.RestExecutor
+import com.kevin.cryptotrader.live.RestRequest
+import com.kevin.cryptotrader.live.UserEventSource
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.nio.charset.StandardCharsets
+import java.time.Clock
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.add
+
+class CoinbaseExchangeAdapter(
+    private val apiKey: String,
+    private val secretKey: String,
+    private val passphrase: String,
+    private val rest: RestExecutor,
+    private val events: UserEventSource,
+    private val clock: Clock = Clock.systemUTC(),
+    private val json: Json = Json { ignoreUnknownKeys = true }
+) : ExchangeAdapter {
+    private val openOrders = ConcurrentHashMap<String, String>()
+    private val secretBytes = Base64.getDecoder().decode(secretKey)
+
+    override suspend fun place(order: Order): String {
+        val clientOrderId = order.clientOrderId.ifEmpty { orderId(order) }
+        val payload = buildJsonObject {
+            put("client_order_id", clientOrderId)
+            put("product_id", order.symbol)
+            put("side", order.side.name.lowercase())
+            put("order_configuration", orderConfig(order))
+        }
+        val body = json.encodeToString(JsonObject.serializer(), payload)
+        val headers = authHeaders("POST", "/api/v3/brokerage/orders", body)
+        val response = rest.execute(
+            RestRequest(
+                method = "POST",
+                path = "/api/v3/brokerage/orders",
+                body = body,
+                headers = headers,
+                contentType = "application/json"
+            )
+        )
+        val success = response["success"]?.jsonPrimitive?.booleanOrNull ?: true
+        if (!success) {
+            val reason = response["failure_reason"]?.jsonPrimitive?.content
+            throw IllegalStateException("Coinbase rejected order: $reason")
+        }
+        openOrders[clientOrderId] = order.symbol
+        return clientOrderId
+    }
+
+    override suspend fun cancel(orderId: String): Boolean {
+        if (!openOrders.containsKey(orderId)) return false
+        val payload = buildJsonObject {
+            put("client_order_ids", buildJsonArray { add(orderId) })
+        }
+        val body = json.encodeToString(JsonObject.serializer(), payload)
+        val headers = authHeaders("POST", "/api/v3/brokerage/orders/batch_cancel", body)
+        val response = rest.execute(
+            RestRequest(
+                method = "POST",
+                path = "/api/v3/brokerage/orders/batch_cancel",
+                body = body,
+                headers = headers,
+                contentType = "application/json"
+            )
+        )
+        val results = response["results"]?.jsonArray ?: return false
+        val canceled = results.any { result ->
+            val obj = result.jsonObject
+            obj["success"]?.jsonPrimitive?.booleanOrNull == true &&
+                obj["client_order_id"]?.jsonPrimitive?.content == orderId
+        }
+        if (canceled) {
+            openOrders.remove(orderId)
+        }
+        return canceled
+    }
+
+    override fun streamEvents(accounts: Set<String>): Flow<BrokerEvent> = events.stream(accounts)
+
+    override suspend fun account(): AccountSnapshot {
+        val headers = authHeaders("GET", "/api/v3/brokerage/accounts", "")
+        val response = rest.execute(
+            RestRequest(
+                method = "GET",
+                path = "/api/v3/brokerage/accounts",
+                headers = headers
+            )
+        )
+        val balances = parseAccounts(response)
+        val equity = balances.filterKeys { it in STABLE_COINS }.values.sum()
+        return AccountSnapshot(equity, balances)
+    }
+
+    private fun parseAccounts(response: JsonObject): Map<String, Double> {
+        val accounts = response["accounts"]?.jsonArray ?: return emptyMap()
+        return accounts.associate { element ->
+            val obj = element.jsonObject
+            val asset = obj["currency"]!!.jsonPrimitive.content
+            val available = obj["available_balance"]?.jsonObject
+            val value = available?.get("value")?.jsonPrimitive?.content?.toDouble() ?: 0.0
+            asset to value
+        }.filterValues { it > 0.0 }
+    }
+
+    private fun orderConfig(order: Order): JsonObject = when (order.type) {
+        OrderType.MARKET -> buildJsonObject {
+            put(
+                "market_market_ioc",
+                buildJsonObject {
+                    put("base_size", format(order.qty))
+                }
+            )
+        }
+        OrderType.LIMIT -> buildJsonObject {
+            put(
+                "limit_limit_gtc",
+                buildJsonObject {
+                    put("base_size", format(order.qty))
+                    put("limit_price", format(order.price ?: error("Limit price required")))
+                    put("post_only", order.tif == TIF.GTC)
+                }
+            )
+        }
+        OrderType.STOP, OrderType.STOP_LIMIT -> buildJsonObject {
+            put(
+                "stop_limit_stop_limit_gtc",
+                buildJsonObject {
+                    put("base_size", format(order.qty))
+                    put("limit_price", format(order.price ?: order.stopPrice ?: error("Price required")))
+                    put("stop_price", format(order.stopPrice ?: error("Stop required")))
+                }
+            )
+        }
+    }
+
+    private fun authHeaders(method: String, path: String, body: String): Map<String, String> {
+        val timestamp = clock.instant().epochSecond.toString()
+        val prehash = timestamp + method.uppercase() + path + body
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secretBytes, "HmacSHA256"))
+        val signature = mac.doFinal(prehash.toByteArray(StandardCharsets.UTF_8))
+        val encoded = Base64.getEncoder().encodeToString(signature)
+        return mapOf(
+            "CB-ACCESS-KEY" to apiKey,
+            "CB-ACCESS-PASSPHRASE" to passphrase,
+            "CB-ACCESS-TIMESTAMP" to timestamp,
+            "CB-ACCESS-SIGN" to encoded,
+            "Content-Type" to "application/json"
+        )
+    }
+
+    private fun format(value: Double): String =
+        BigDecimal.valueOf(value).setScale(SCALE, RoundingMode.DOWN).stripTrailingZeros().toPlainString()
+
+    private fun orderId(order: Order): String = "cb_${order.symbol.lowercase()}_${clock.millis()}"
+
+    companion object {
+        private const val SCALE = 12
+        private val STABLE_COINS = setOf("USD", "USDC", "USDT")
+    }
+}

--- a/livebroker/src/test/kotlin/com/kevin/cryptotrader/live/LiveBrokerAdaptersTest.kt
+++ b/livebroker/src/test/kotlin/com/kevin/cryptotrader/live/LiveBrokerAdaptersTest.kt
@@ -1,0 +1,125 @@
+package com.kevin.cryptotrader.live
+
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.contracts.TIF
+import com.kevin.cryptotrader.live.binance.BinanceExchangeAdapter
+import com.kevin.cryptotrader.live.coinbase.CoinbaseExchangeAdapter
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.Base64
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LiveBrokerAdaptersTest {
+    private val clock = object : Clock() {
+        private val instant = Instant.parse("2024-05-01T00:00:00Z")
+        override fun getZone(): ZoneId = ZoneId.of("UTC")
+        override fun withZone(zone: ZoneId): Clock = this
+        override fun instant(): Instant = instant
+    }
+
+    @Test
+    fun `binance adapter signs requests and parses balances`() = runTest {
+        val rest = RecordingExecutor(
+            response = Json.parseToJsonElement(
+                """
+                {"orderId":12345,"clientOrderId":"my-id","status":"NEW"}
+                """.trimIndent()
+            ).jsonObject
+        )
+        val events = UserEventSource { emptyFlow() }
+        val adapter = BinanceExchangeAdapter(
+            apiKey = "key",
+            secretKey = "secret",
+            rest = rest,
+            events = events,
+            clock = clock,
+            recvWindowMs = 5000
+        )
+        val order = Order(
+            clientOrderId = "my-id",
+            symbol = "BTCUSDT",
+            side = Side.BUY,
+            type = OrderType.LIMIT,
+            qty = 0.5,
+            price = 25_000.0,
+            stopPrice = null,
+            tif = TIF.GTC,
+            ts = 0L
+        )
+        val id = adapter.place(order)
+        assertEquals("my-id", id)
+        val request = rest.lastRequest
+        assertEquals("/api/v3/order", request?.path)
+        assertTrue(request?.query?.containsKey("signature") == true)
+        assertEquals("key", request?.headers?.get("X-MBX-APIKEY"))
+
+        rest.response = Json.parseToJsonElement(
+            """
+            {"balances":[{"asset":"USDT","free":"100.0","locked":"0"},{"asset":"BTC","free":"0.1","locked":"0"}]}
+            """.trimIndent()
+        ).jsonObject
+        val snapshot = adapter.account()
+        assertEquals(100.0, snapshot.equityUsd)
+        assertEquals(2, snapshot.balances.size)
+    }
+
+    @Test
+    fun `coinbase adapter builds JSON payload`() = runTest {
+        val rest = RecordingExecutor(
+            response = Json.parseToJsonElement("""{"success":true}""").jsonObject
+        )
+        val adapter = CoinbaseExchangeAdapter(
+            apiKey = "key",
+            secretKey = Base64.getEncoder().encodeToString("secret".toByteArray()),
+            passphrase = "pass",
+            rest = rest,
+            events = UserEventSource { emptyFlow() },
+            clock = clock,
+            json = Json
+        )
+        val order = Order(
+            clientOrderId = "",
+            symbol = "ETH-USD",
+            side = Side.SELL,
+            type = OrderType.MARKET,
+            qty = 1.5,
+            price = null,
+            stopPrice = null,
+            tif = TIF.IOC,
+            ts = 0L
+        )
+        val id = adapter.place(order)
+        assertTrue(id.startsWith("cb_eth-usd_"))
+        val request = rest.lastRequest
+        assertEquals("/api/v3/brokerage/orders", request?.path)
+        assertEquals("POST", request?.method?.uppercase())
+        assertEquals("application/json", request?.contentType)
+        assertTrue(request?.headers?.containsKey("CB-ACCESS-SIGN") == true)
+
+        rest.response = Json.parseToJsonElement(
+            """
+            {"accounts":[{"currency":"USD","available_balance":{"value":"120.0"}}]}
+            """.trimIndent()
+        ).jsonObject
+        val account = adapter.account()
+        assertEquals(120.0, account.equityUsd)
+        assertEquals(120.0, account.balances["USD"])
+    }
+
+    private class RecordingExecutor(var response: kotlinx.serialization.json.JsonObject) : RestExecutor {
+        var lastRequest: RestRequest? = null
+        override suspend fun execute(request: RestRequest): kotlinx.serialization.json.JsonObject {
+            lastRequest = request
+            return response
+        }
+    }
+}

--- a/paperbroker/src/main/kotlin/com/kevin/cryptotrader/paper/PaperBroker.kt
+++ b/paperbroker/src/main/kotlin/com/kevin/cryptotrader/paper/PaperBroker.kt
@@ -1,0 +1,397 @@
+package com.kevin.cryptotrader.paper
+
+import com.kevin.cryptotrader.contracts.AccountSnapshot
+import com.kevin.cryptotrader.contracts.Broker
+import com.kevin.cryptotrader.contracts.BrokerEvent
+import com.kevin.cryptotrader.contracts.Fill
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderBookDelta
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.Side
+import java.security.SecureRandom
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.absoluteValue
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.round
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A deterministic, depth-aware paper trading broker. The implementation simulates
+ * fills against a level-2 order book, applies maker/taker fees, tracks balances
+ * and emits broker events via a [Flow]. All state mutations are serialized via a
+ * [Mutex] so the broker is safe to call from concurrent coroutines during tests.
+ */
+class PaperBroker(
+    private val clock: Clock = Clock.systemUTC(),
+    makerFeeBps: Double = 0.0,
+    takerFeeBps: Double = 0.0,
+    initialBalances: Map<String, Double> = emptyMap(),
+    private val eventBuffer: Int = DEFAULT_EVENT_BUFFER
+) : Broker {
+    private val makerFeeRate = makerFeeBps / 10_000.0
+    private val takerFeeRate = takerFeeBps / 10_000.0
+    private val mutex = Mutex()
+    private val balances = initialBalances.toMutableMap()
+    private val books = mutableMapOf<String, MutableOrderBook>()
+    private val openOrders = mutableMapOf<String, MutableList<OpenOrder>>()
+    private val sharedFlow = MutableSharedFlow<BrokerEvent>(extraBufferCapacity = eventBuffer)
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private val idSeed = AtomicLong(SecureRandom().nextLong().absoluteValue)
+
+    override suspend fun place(order: Order): String = mutex.withLock {
+        if (order.type !in SUPPORTED_ORDER_TYPES) {
+            emitEvent(
+                BrokerEvent.Rejected(
+                    order.clientOrderId.ifEmpty { generateOrderId(order.symbol) },
+                    "Unsupported order type ${order.type}"
+                )
+            )
+            return order.clientOrderId
+        }
+
+        val normalized = normalizeOrder(order)
+        val orderId = normalized.clientOrderId
+        emitEvent(BrokerEvent.Accepted(orderId, normalized))
+
+        val book = books[normalized.symbol]
+        val takerResult = if (book != null) {
+            book.match(normalized.side, normalized.qty, normalized.price)
+        } else {
+            MatchResult.empty(normalized.qty)
+        }
+
+        val takerFills = takerResult.fills
+        val takerQty = takerFills.sumOf { it.qty }
+        if (takerQty > 0.0) {
+            applyFillEffects(
+                normalized,
+                takerFills,
+                takerFeeRate
+            )
+        }
+
+        if (takerFills.isEmpty() && normalized.type == OrderType.MARKET) {
+            emitEvent(
+                BrokerEvent.Rejected(
+                    normalized.clientOrderId,
+                    "No liquidity available for market order"
+                )
+            )
+            return@withLock normalized.clientOrderId
+        }
+
+        val remaining = takerResult.remainingQty
+        if (remaining > EPS) {
+            if (normalized.type == OrderType.MARKET) {
+                emitFillEvent(normalized, takerFills, isTerminal = false)
+                return@withLock normalized.clientOrderId
+            }
+            if (!reserveForMaker(normalized, remaining)) {
+                // Unable to reserve capital -> reject leftover and unwind taker fills
+                rollbackFills(normalized, takerFills, takerFeeRate)
+                emitEvent(
+                    BrokerEvent.Rejected(
+                        orderId,
+                        "Insufficient balance to reserve maker order"
+                    )
+                )
+                return@withLock orderId
+            }
+            registerOpenOrder(normalized, remaining)
+        }
+
+        emitFillEvent(normalized, takerFills, remaining <= EPS)
+
+        orderId
+    }
+
+    override suspend fun cancel(clientOrderId: String): Boolean = mutex.withLock {
+        val open = openOrders.values.firstNotNullOfOrNull { list ->
+            list.firstOrNull { it.order.clientOrderId == clientOrderId }
+        } ?: return@withLock false
+        releaseReserve(open)
+        removeOpenOrder(open.order.symbol, clientOrderId)
+        emitEvent(BrokerEvent.Canceled(clientOrderId))
+        true
+    }
+
+    override fun streamEvents(accounts: Set<String>): Flow<BrokerEvent> = sharedFlow.asSharedFlow()
+
+    override suspend fun account(): AccountSnapshot = mutex.withLock {
+        val equity = balances.filterKeys { it in QUOTE_ASSETS }
+            .values
+            .sum()
+        AccountSnapshot(equity, balances.toMap())
+    }
+
+    /** Applies a fresh order book snapshot for [symbol]. */
+    suspend fun updateOrderBook(delta: OrderBookDelta) {
+        mutex.withLock {
+            val book = books.getOrPut(delta.symbol) { MutableOrderBook() }
+            book.applySnapshot(delta)
+            processRestingOrders(delta.symbol, book)
+        }
+    }
+
+    fun close() {
+        scope.cancel()
+    }
+
+    private fun emitEvent(event: BrokerEvent) {
+        if (!sharedFlow.tryEmit(event)) {
+            scope.launch { sharedFlow.emit(event) }
+        }
+    }
+
+    private fun normalizeOrder(order: Order): Order {
+        val id = if (order.clientOrderId.isNullOrEmpty()) {
+            generateOrderId(order.symbol)
+        } else {
+            order.clientOrderId
+        }
+        val ts = if (order.ts > 0) order.ts else clock.millis()
+        return order.copy(clientOrderId = id, ts = ts)
+    }
+
+    private fun generateOrderId(symbol: String): String {
+        val suffix = idSeed.incrementAndGet().toString(36)
+        return "pb_${symbol.lowercase()}_$suffix"
+    }
+
+    private fun registerOpenOrder(order: Order, remaining: Double) {
+        val list = openOrders.getOrPut(order.symbol) { mutableListOf() }
+        list += OpenOrder(order, remaining, clock.millis())
+    }
+
+    private fun removeOpenOrder(symbol: String, id: String) {
+        openOrders[symbol]?.removeAll { it.order.clientOrderId == id }
+        if (openOrders[symbol].isNullOrEmpty()) {
+            openOrders.remove(symbol)
+        }
+    }
+
+    private fun releaseReserve(open: OpenOrder) {
+        val (base, quote) = splitSymbol(open.order.symbol)
+        when (open.order.side) {
+            Side.BUY -> adjustBalance(quote, open.remainingQty * (open.order.price ?: 0.0))
+            Side.SELL -> adjustBalance(base, open.remainingQty)
+        }
+    }
+
+    private fun reserveForMaker(order: Order, remaining: Double): Boolean {
+        val (base, quote) = splitSymbol(order.symbol)
+        return when (order.side) {
+            Side.BUY -> {
+                val required = remaining * (order.price ?: return false)
+                val current = balances[quote] ?: 0.0
+                if (current + EPS < required) {
+                    false
+                } else {
+                    balances[quote] = current - required
+                    true
+                }
+            }
+            Side.SELL -> {
+                val available = balances[base] ?: 0.0
+                if (available + EPS < remaining) {
+                    false
+                } else {
+                    balances[base] = available - remaining
+                    true
+                }
+            }
+        }
+    }
+
+    private fun rollbackFills(order: Order, fills: List<FillDetail>, feeRate: Double) {
+        if (fills.isEmpty()) return
+        val (base, quote) = splitSymbol(order.symbol)
+        val total = fills.sumOf { it.qty }
+        val value = fills.sumOf { it.qty * it.price }
+        when (order.side) {
+            Side.BUY -> {
+                adjustBalance(base, -total)
+                adjustBalance(quote, value * (1 + feeRate))
+            }
+            Side.SELL -> {
+                adjustBalance(base, total)
+                adjustBalance(quote, -value * (1 - feeRate))
+            }
+        }
+    }
+
+    private fun applyFillEffects(
+        order: Order,
+        fills: List<FillDetail>,
+        feeRate: Double
+    ) {
+        if (fills.isEmpty()) return
+        val (base, quote) = splitSymbol(order.symbol)
+        val fillQty = fills.sumOf { it.qty }
+        val fillValue = fills.sumOf { it.qty * it.price }
+        val fee = fillValue * feeRate
+        when (order.side) {
+            Side.BUY -> {
+                adjustBalance(base, fillQty)
+                adjustBalance(quote, -(fillValue + fee))
+            }
+            Side.SELL -> {
+                adjustBalance(base, -fillQty)
+                adjustBalance(quote, fillValue - fee)
+            }
+        }
+    }
+
+    private fun emitFillEvent(order: Order, fills: List<FillDetail>, isTerminal: Boolean) {
+        if (fills.isEmpty()) return
+        val total = fills.sumOf { it.qty }
+        val price = fills.sumOf { it.qty * it.price } / total
+        val fill = Fill(order.clientOrderId, total, price, clock.millis())
+        val event = if (isTerminal) {
+            BrokerEvent.Filled(order.clientOrderId, fill)
+        } else {
+            BrokerEvent.PartialFill(order.clientOrderId, fill)
+        }
+        emitEvent(event)
+    }
+
+    private fun processRestingOrders(symbol: String, book: MutableOrderBook) {
+        val orders = openOrders[symbol] ?: return
+        val iterator = orders.iterator()
+        while (iterator.hasNext()) {
+            val open = iterator.next()
+            val price = open.order.price ?: continue
+            val shouldFill = when (open.order.side) {
+                Side.BUY -> book.bestAsk()?.let { it <= price + EPS } == true
+                Side.SELL -> book.bestBid()?.let { it >= price - EPS } == true
+            }
+            if (!shouldFill) continue
+            val makerFill = FillDetail(open.remainingQty, price)
+            releaseReserve(open)
+            applyFillEffects(open.order, listOf(makerFill), makerFeeRate)
+            emitFillEvent(open.order, listOf(makerFill), isTerminal = true)
+            iterator.remove()
+        }
+        if (orders.isEmpty()) {
+            openOrders.remove(symbol)
+        }
+    }
+
+    private fun adjustBalance(asset: String, delta: Double) {
+        if (delta.absoluteValue <= EPS) return
+        val updated = (balances[asset] ?: 0.0) + delta
+        balances[asset] = round(updated * BALANCE_PRECISION).div(BALANCE_PRECISION)
+    }
+
+    private fun splitSymbol(symbol: String): Pair<String, String> {
+        for (quote in QUOTE_ASSETS) {
+            if (symbol.endsWith(quote)) {
+                val base = symbol.removeSuffix(quote)
+                if (base.isNotEmpty()) {
+                    return base to quote
+                }
+            }
+        }
+        require(symbol.length > 3) { "Unable to split symbol $symbol" }
+        val base = symbol.dropLast(3)
+        val quote = symbol.takeLast(3)
+        return base to quote
+    }
+
+    private data class OpenOrder(
+        val order: Order,
+        var remainingQty: Double,
+        val createdAt: Long
+    )
+
+    private class MutableOrderBook {
+        private val bids = mutableListOf<Level>()
+        private val asks = mutableListOf<Level>()
+
+        fun applySnapshot(delta: OrderBookDelta) {
+            bids.clear()
+            asks.clear()
+            delta.bids.sortedByDescending { it.first }
+                .mapTo(bids) { Level(it.first, it.second) }
+            delta.asks.sortedBy { it.first }
+                .mapTo(asks) { Level(it.first, it.second) }
+        }
+
+        fun match(side: Side, qty: Double, limitPrice: Double?): MatchResult {
+            return when (side) {
+                Side.BUY -> consume(asks, qty, limitPrice, isBuy = true)
+                Side.SELL -> consume(bids, qty, limitPrice, isBuy = false)
+            }
+        }
+
+        fun bestAsk(): Double? = asks.firstOrNull()?.price
+        fun bestBid(): Double? = bids.firstOrNull()?.price
+
+        private fun consume(
+            levels: MutableList<Level>,
+            qty: Double,
+            limitPrice: Double?,
+            isBuy: Boolean
+        ): MatchResult {
+            if (qty <= EPS) return MatchResult.empty(0.0)
+            var remaining = qty
+            val fills = mutableListOf<FillDetail>()
+            var index = 0
+            while (remaining > EPS && index < levels.size) {
+                val level = levels[index]
+                val price = level.price
+                if (limitPrice != null) {
+                    val violatesLimit = if (isBuy) {
+                        price > limitPrice + EPS
+                    } else {
+                        price < limitPrice - EPS
+                    }
+                    if (violatesLimit) break
+                }
+                val fillQty = min(remaining, level.qty)
+                if (fillQty <= EPS) {
+                    index++
+                    continue
+                }
+                fills += FillDetail(fillQty, price)
+                remaining -= fillQty
+                val leftover = level.qty - fillQty
+                if (leftover <= EPS) {
+                    levels.removeAt(index)
+                } else {
+                    levels[index] = level.copy(qty = leftover)
+                    index++
+                }
+            }
+            return MatchResult(fills, remaining)
+        }
+    }
+
+    private data class Level(val price: Double, val qty: Double)
+
+    private data class FillDetail(val qty: Double, val price: Double)
+
+    private data class MatchResult(val fills: List<FillDetail>, val remainingQty: Double) {
+        companion object {
+            fun empty(remaining: Double) = MatchResult(emptyList(), remaining)
+        }
+    }
+
+    companion object {
+        private const val EPS = 1e-9
+        private val BALANCE_PRECISION = 10.0.pow(8)
+        private const val DEFAULT_EVENT_BUFFER = 128
+        private val QUOTE_ASSETS = setOf("USD", "USDT", "USDC", "BUSD", "EUR")
+        private val SUPPORTED_ORDER_TYPES = setOf(OrderType.MARKET, OrderType.LIMIT)
+    }
+}

--- a/paperbroker/src/test/kotlin/com/kevin/cryptotrader/paper/PaperBrokerTest.kt
+++ b/paperbroker/src/test/kotlin/com/kevin/cryptotrader/paper/PaperBrokerTest.kt
@@ -1,0 +1,152 @@
+package com.kevin.cryptotrader.paper
+
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderBookDelta
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.contracts.TIF
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class PaperBrokerTest {
+    private val clock = MutableTestClock()
+    private val broker = PaperBroker(
+        clock = clock,
+        makerFeeBps = 5.0,
+        takerFeeBps = 10.0,
+        initialBalances = mapOf("USDT" to 1_000.0)
+    )
+
+    @AfterEach
+    fun tearDown() {
+        broker.close()
+    }
+
+    @Test
+    fun `market buy consumes top of book with taker fees`() = runTest {
+        broker.updateOrderBook(
+            OrderBookDelta(
+                ts = 0,
+                symbol = "BTCUSDT",
+                bids = listOf(99.0 to 1.0),
+                asks = listOf(100.0 to 0.5, 101.0 to 0.5)
+            )
+        )
+
+        val orderId = broker.place(
+            Order(
+                clientOrderId = "",
+                symbol = "BTCUSDT",
+                side = Side.BUY,
+                type = OrderType.MARKET,
+                qty = 0.4,
+                price = null,
+                stopPrice = null,
+                tif = TIF.GTC,
+                ts = 0L
+            )
+        )
+
+        val snapshot = broker.account()
+        assertEquals(0.4, snapshot.balances["BTC"] ?: 0.0, 1e-9)
+        val expectedQuote = 1_000.0 - (0.4 * 100.0) - (0.4 * 100.0 * 0.001)
+        assertEquals(expectedQuote, snapshot.balances["USDT"] ?: 0.0, 1e-6)
+        assertTrue(orderId.startsWith("pb_btcusdt_"))
+    }
+
+    @Test
+    fun `limit order rests then fills on cross with maker fees`() = runTest {
+        val broker = PaperBroker(
+            clock = clock,
+            makerFeeBps = 2.0,
+            takerFeeBps = 10.0,
+            initialBalances = mapOf("USDT" to 2_000.0)
+        )
+
+        try {
+
+        broker.updateOrderBook(
+            OrderBookDelta(0, "ETHUSDT", bids = listOf(1800.0 to 1.0), asks = listOf(1810.0 to 1.0))
+        )
+
+        val orderId = broker.place(
+            Order(
+                clientOrderId = "manual-id",
+                symbol = "ETHUSDT",
+                side = Side.BUY,
+                type = OrderType.LIMIT,
+                qty = 0.5,
+                price = 1800.0,
+                stopPrice = null,
+                tif = TIF.GTC,
+                ts = 0L
+            )
+        )
+        assertEquals("manual-id", orderId)
+        val reserved = broker.account().balances["USDT"] ?: error("missing reserve")
+        assertEquals(2_000.0 - 0.5 * 1800.0, reserved, 1e-6)
+
+        broker.updateOrderBook(
+            OrderBookDelta(1, "ETHUSDT", bids = listOf(1799.0 to 1.0), asks = listOf(1795.0 to 2.0))
+        )
+
+        val snapshot = broker.account()
+        assertEquals(0.5, snapshot.balances["ETH"] ?: 0.0, 1e-9)
+        val expectedQuote = 2_000.0 - (0.5 * 1800.0) - (0.5 * 1800.0 * 0.0002)
+        assertEquals(expectedQuote, snapshot.balances["USDT"] ?: 0.0, 1e-6)
+        } finally {
+            broker.close()
+        }
+    }
+
+    @Test
+    fun `canceling open order releases reserved balances`() = runTest {
+        val broker = PaperBroker(
+            clock = clock,
+            makerFeeBps = 0.0,
+            takerFeeBps = 0.0,
+            initialBalances = mapOf("USDT" to 1_000.0)
+        )
+        try {
+            broker.updateOrderBook(OrderBookDelta(0, "BTCUSDT", bids = emptyList(), asks = listOf(15000.0 to 1.0)))
+
+            val id = broker.place(
+                Order(
+                    clientOrderId = "",
+                    symbol = "BTCUSDT",
+                    side = Side.BUY,
+                    type = OrderType.LIMIT,
+                    qty = 0.1,
+                    price = 9000.0,
+                    stopPrice = null,
+                    tif = TIF.GTC,
+                    ts = 0L
+                )
+            )
+            val afterPlace = broker.account().balances["USDT"] ?: 0.0
+            assertEquals(1_000.0 - 900.0, afterPlace, 1e-6)
+
+            assertTrue(broker.cancel(id))
+            val afterCancel = broker.account().balances["USDT"] ?: 0.0
+            assertEquals(1_000.0, afterCancel, 1e-6)
+        } finally {
+            broker.close()
+        }
+    }
+
+    private class MutableTestClock : Clock() {
+        private var instant: Instant = Instant.parse("2024-01-01T00:00:00Z")
+        override fun getZone(): ZoneId = ZoneId.of("UTC")
+        override fun withZone(zone: ZoneId?): Clock = this
+        override fun instant(): Instant = instant
+        fun advanceMillis(delta: Long) {
+            instant = instant.plusMillis(delta)
+        }
+    }
+}

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
   testImplementation(kotlin("test"))
   testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 }
 
 tasks.test { useJUnitPlatform() }

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/DefaultPolicyEngine.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/DefaultPolicyEngine.kt
@@ -1,0 +1,97 @@
+package com.kevin.cryptotrader.runtime.execution
+
+import com.kevin.cryptotrader.contracts.Intent
+import com.kevin.cryptotrader.contracts.NetPlan
+import com.kevin.cryptotrader.contracts.PolicyEngine
+import com.kevin.cryptotrader.contracts.Position
+import com.kevin.cryptotrader.contracts.Side
+import java.util.UUID
+import kotlin.math.absoluteValue
+
+class DefaultPolicyEngine(
+    private val config: ExecutionConfig
+) : PolicyEngine {
+    override fun net(intents: List<Intent>, positions: List<Position>): NetPlan {
+        val prioritized = prioritize(intents)
+        val voted = applyVoting(prioritized)
+        val netted = netBySymbol(voted)
+        val targeted = applyTargets(netted, positions)
+        return NetPlan(targeted)
+    }
+
+    private fun prioritize(intents: List<Intent>): List<Intent> {
+        if (config.priorityOrder.isEmpty()) return intents
+        val priorityIndex = config.priorityOrder.withIndex().associate { it.value to it.index }
+        return intents.sortedBy { priorityIndex[it.kind] ?: Int.MAX_VALUE }
+    }
+
+    private fun applyVoting(intents: List<Intent>): List<Intent> {
+        val voteConfig = config.vote ?: return intents
+        if (voteConfig.threshold <= 1) return intents
+        val grouped = intents.groupBy { it.meta[voteConfig.groupKey] ?: it.symbol }
+        return grouped.values.flatMap { group ->
+            if (group.size >= voteConfig.threshold) group else emptyList()
+        }
+    }
+
+    private fun netBySymbol(intents: List<Intent>): List<Intent> {
+        if (intents.isEmpty()) return emptyList()
+        val grouped = intents.groupBy { it.symbol to it.side }
+        return grouped.mapNotNull { (key, bucket) ->
+            val (symbol, side) = key
+            val qty = bucket.sumOf { it.qty ?: 0.0 }
+            val notional = bucket.sumOf { it.notionalUsd ?: 0.0 }
+            if (qty <= 0.0 && notional <= 0.0) {
+                null
+            } else {
+                val priceHints = bucket.mapNotNull { it.priceHint }
+                Intent(
+                    id = "net-${UUID.randomUUID()}",
+                    sourceId = bucket.first().sourceId,
+                    kind = "net:${bucket.first().kind}",
+                    symbol = symbol,
+                    side = side,
+                    notionalUsd = notional.takeIf { it > 0.0 },
+                    qty = qty.takeIf { it > 0.0 },
+                    priceHint = priceHints.takeIf { it.isNotEmpty() }?.average(),
+                    meta = mapOf("netted_from" to bucket.joinToString(",") { it.id })
+                )
+            }
+        }
+    }
+
+    private fun applyTargets(intents: List<Intent>, positions: List<Position>): List<Intent> {
+        if (config.portfolioTargets.isEmpty()) return intents
+        val currentPositions = positions.groupBy { it.symbol }
+            .mapValues { (_, pos) -> pos.sumOf { it.qty } }
+        val bySymbol = intents.groupBy { it.symbol }
+        val retained = intents.filter { it.symbol !in config.portfolioTargets.keys }
+        val adjustments = mutableListOf<Intent>()
+        for ((symbol, targetQty) in config.portfolioTargets) {
+            val current = currentPositions[symbol] ?: 0.0
+            val plannedDelta = bySymbol[symbol]?.sumOf { intent ->
+                val qty = intent.qty ?: 0.0
+                if (intent.side == Side.BUY) qty else -qty
+            } ?: 0.0
+            val delta = targetQty - current - plannedDelta
+            if (delta.absoluteValue <= EPS) continue
+            val side = if (delta > 0) Side.BUY else Side.SELL
+            adjustments += Intent(
+                id = "target-${UUID.randomUUID()}",
+                sourceId = "portfolio.target",
+                kind = "portfolio-target",
+                symbol = symbol,
+                side = side,
+                notionalUsd = null,
+                qty = delta.absoluteValue,
+                priceHint = null,
+                meta = mapOf("target" to targetQty.toString())
+            )
+        }
+        return retained + adjustments
+    }
+
+    companion object {
+        private const val EPS = 1e-9
+    }
+}

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionConfig.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionConfig.kt
@@ -1,0 +1,16 @@
+package com.kevin.cryptotrader.runtime.execution
+
+import java.time.Duration
+
+data class ExecutionConfig(
+    val cooldown: Duration = Duration.ZERO,
+    val priorityOrder: List<String> = emptyList(),
+    val vote: VoteConfig? = null,
+    val portfolioTargets: Map<String, Double> = emptyMap(),
+    val maxIntentCache: Int = 1024
+)
+
+data class VoteConfig(
+    val threshold: Int,
+    val groupKey: String = "voteGroup"
+)

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionCoordinator.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionCoordinator.kt
@@ -1,0 +1,79 @@
+package com.kevin.cryptotrader.runtime.execution
+
+import com.kevin.cryptotrader.contracts.Broker
+import com.kevin.cryptotrader.contracts.Intent
+import com.kevin.cryptotrader.contracts.PolicyEngine
+import com.kevin.cryptotrader.contracts.Position
+import com.kevin.cryptotrader.contracts.RiskSizer
+import java.time.Clock
+import java.time.Duration
+import java.util.ArrayDeque
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class ExecutionCoordinator(
+    private val broker: Broker,
+    private val policyEngine: PolicyEngine,
+    private val riskSizer: RiskSizer,
+    private val ledger: Ledger,
+    private val clock: Clock = Clock.systemUTC(),
+    private val config: ExecutionConfig = ExecutionConfig()
+) {
+    private val mutex = Mutex()
+    private val processedIds = ArrayDeque<String>()
+    private val processedSet = linkedSetOf<String>()
+    private val lastSourceExecution = mutableMapOf<String, Long>()
+
+    suspend fun coordinate(intents: List<Intent>, positions: List<Position>) {
+        val accepted = filterIntents(intents)
+        if (accepted.isEmpty()) return
+        val now = clock.millis()
+        ledger.append(LedgerEvent.IntentsRecorded(now, accepted))
+
+        val netPlan = policyEngine.net(accepted, positions)
+        ledger.append(LedgerEvent.NetPlanReady(now, netPlan))
+
+        val account = broker.account()
+        val orders = riskSizer.size(netPlan, account)
+        if (orders.isEmpty()) return
+        ledger.append(LedgerEvent.OrdersSized(now, orders))
+
+        for (order in orders) {
+            val brokerId = broker.place(order)
+            ledger.append(LedgerEvent.OrderRouted(clock.millis(), order, brokerId))
+        }
+    }
+
+    private suspend fun filterIntents(intents: List<Intent>): List<Intent> = mutex.withLock {
+        val accepted = mutableListOf<Intent>()
+        val cooldownMs = config.cooldown.toMillisSafe()
+        val now = clock.millis()
+        val acceptedSources = mutableSetOf<String>()
+        for (intent in intents) {
+            if (config.maxIntentCache > 0 && processedSet.contains(intent.id)) continue
+            val last = lastSourceExecution[intent.sourceId]
+            if (last != null && cooldownMs > 0 && now - last < cooldownMs && intent.sourceId !in acceptedSources) {
+                continue
+            }
+            acceptedSources += intent.sourceId
+            recordIntentId(intent.id)
+            accepted += intent
+        }
+        for (source in acceptedSources) {
+            lastSourceExecution[source] = now
+        }
+        accepted
+    }
+
+    private fun recordIntentId(id: String) {
+        if (config.maxIntentCache <= 0) return
+        processedSet.add(id)
+        processedIds.addLast(id)
+        while (processedIds.size > config.maxIntentCache) {
+            val removed = processedIds.removeFirst()
+            processedSet.remove(removed)
+        }
+    }
+
+    private fun Duration.toMillisSafe(): Long = if (this.isZero) 0L else this.toMillis()
+}

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/Ledger.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/Ledger.kt
@@ -1,0 +1,18 @@
+package com.kevin.cryptotrader.runtime.execution
+
+import com.kevin.cryptotrader.contracts.Intent
+import com.kevin.cryptotrader.contracts.NetPlan
+import com.kevin.cryptotrader.contracts.Order
+
+interface Ledger {
+    suspend fun append(event: LedgerEvent)
+}
+
+sealed interface LedgerEvent {
+    val timestamp: Long
+
+    data class IntentsRecorded(override val timestamp: Long, val intents: List<Intent>) : LedgerEvent
+    data class NetPlanReady(override val timestamp: Long, val netPlan: NetPlan) : LedgerEvent
+    data class OrdersSized(override val timestamp: Long, val orders: List<Order>) : LedgerEvent
+    data class OrderRouted(override val timestamp: Long, val order: Order, val brokerOrderId: String) : LedgerEvent
+}

--- a/runtime/src/test/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionCoordinatorTest.kt
+++ b/runtime/src/test/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionCoordinatorTest.kt
@@ -1,0 +1,200 @@
+package com.kevin.cryptotrader.runtime.execution
+
+import com.kevin.cryptotrader.contracts.AccountSnapshot
+import com.kevin.cryptotrader.contracts.Broker
+import com.kevin.cryptotrader.contracts.BrokerEvent
+import com.kevin.cryptotrader.contracts.Intent
+import com.kevin.cryptotrader.contracts.NetPlan
+import com.kevin.cryptotrader.contracts.Order
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.Position
+import com.kevin.cryptotrader.contracts.RiskSizer
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.contracts.TIF
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class ExecutionCoordinatorTest {
+    private val clock = object : Clock() {
+        private val instant = Instant.parse("2024-06-01T00:00:00Z")
+        override fun getZone(): ZoneId = ZoneId.of("UTC")
+        override fun withZone(zone: ZoneId): Clock = this
+        override fun instant(): Instant = instant
+    }
+
+    @Test
+    fun `coordinator enforces idempotency cooldown and policies`() = runTest {
+        val config = ExecutionConfig(
+            cooldown = Duration.ofMinutes(5),
+            priorityOrder = listOf("high", "low"),
+            vote = VoteConfig(threshold = 2, groupKey = "vote"),
+            portfolioTargets = mapOf("SOLUSDT" to 5.0)
+        )
+        val ledger = RecordingLedger()
+        val broker = RecordingBroker()
+        val riskSizer = PassthroughRiskSizer()
+        val policy = DefaultPolicyEngine(config)
+        val coordinator = ExecutionCoordinator(broker, policy, riskSizer, ledger, clock, config)
+
+        val intents = listOf(
+            intent(
+                id = "h1",
+                source = "alpha",
+                kind = "high",
+                symbol = "ETHUSDT",
+                side = Side.BUY,
+                qty = 1.0,
+                vote = "group-eth"
+            ),
+            intent(
+                id = "h2",
+                source = "alpha",
+                kind = "high",
+                symbol = "ETHUSDT",
+                side = Side.BUY,
+                qty = 0.5,
+                vote = "group-eth"
+            ),
+            intent(
+                id = "l1",
+                source = "beta",
+                kind = "low",
+                symbol = "BTCUSDT",
+                side = Side.BUY,
+                qty = 0.3,
+                vote = "group-btc"
+            ),
+            intent(
+                id = "l1-dup",
+                source = "beta",
+                kind = "low",
+                symbol = "BTCUSDT",
+                side = Side.BUY,
+                qty = 0.3,
+                vote = "group-btc"
+            ),
+            intent(
+                id = "dup",
+                source = "beta",
+                kind = "low",
+                symbol = "BTCUSDT",
+                side = Side.BUY,
+                qty = 0.1,
+                vote = "group-btc"
+            ),
+            intent(
+                id = "dup",
+                source = "beta",
+                kind = "low",
+                symbol = "BTCUSDT",
+                side = Side.BUY,
+                qty = 0.1,
+                vote = "group-btc"
+            )
+        )
+        val positions = listOf(
+            Position("acct", "BTCUSDT", 0.2, 0.0, 0.0, 0.0),
+            Position("acct", "SOLUSDT", 1.0, 0.0, 0.0, 0.0)
+        )
+
+        coordinator.coordinate(intents, positions)
+
+        assertEquals(3, broker.placed.size)
+        val sizedNetPlan = requireNotNull(riskSizer.lastNetPlan)
+        assertEquals(3, sizedNetPlan.intents.size)
+        val symbols = sizedNetPlan.intents.map { it.symbol }
+        assertTrue(symbols.containsAll(listOf("ETHUSDT", "BTCUSDT", "SOLUSDT")))
+        assertEquals("ETHUSDT", sizedNetPlan.intents.first().symbol)
+
+        val events = ledger.events
+        assertEquals(5, (events[0] as LedgerEvent.IntentsRecorded).intents.size)
+        assertIs<LedgerEvent.NetPlanReady>(events[1])
+        assertIs<LedgerEvent.OrdersSized>(events[2])
+        assertEquals(3, events.count { it is LedgerEvent.OrderRouted })
+
+        // Cooldown prevents immediate re-processing for the same source.
+        coordinator.coordinate(
+            listOf(
+                intent(
+                    id = "new",
+                    source = "beta",
+                    kind = "low",
+                    symbol = "BTCUSDT",
+                    side = Side.SELL,
+                    qty = 0.5,
+                    vote = "group-btc"
+                )
+            ),
+            positions
+        )
+        assertEquals(3, broker.placed.size)
+    }
+
+    private fun intent(
+        id: String,
+        source: String,
+        kind: String,
+        symbol: String,
+        side: Side,
+        qty: Double,
+        vote: String
+    ): Intent = Intent(
+        id = id,
+        sourceId = source,
+        kind = kind,
+        symbol = symbol,
+        side = side,
+        notionalUsd = null,
+        qty = qty,
+        priceHint = null,
+        meta = mapOf("vote" to vote)
+    )
+
+    private class RecordingLedger : Ledger {
+        val events = mutableListOf<LedgerEvent>()
+        override suspend fun append(event: LedgerEvent) {
+            events += event
+        }
+    }
+
+    private class RecordingBroker : Broker {
+        val placed = mutableListOf<Order>()
+        private val snapshot = AccountSnapshot(10_000.0, mapOf("USDT" to 10_000.0))
+        override suspend fun place(order: Order): String {
+            placed += order
+            return "broker-${placed.size}"
+        }
+        override suspend fun cancel(clientOrderId: String): Boolean = false
+        override fun streamEvents(accounts: Set<String>): Flow<BrokerEvent> = emptyFlow()
+        override suspend fun account(): AccountSnapshot = snapshot
+    }
+
+    private class PassthroughRiskSizer : RiskSizer {
+        var lastNetPlan: NetPlan? = null
+        override fun size(netPlan: NetPlan, account: AccountSnapshot): List<Order> {
+            lastNetPlan = netPlan
+            return netPlan.intents.mapIndexed { index, intent ->
+                Order(
+                    clientOrderId = "sized-$index",
+                    symbol = intent.symbol,
+                    side = intent.side,
+                    type = OrderType.MARKET,
+                    qty = intent.qty ?: 0.0,
+                    price = intent.priceHint,
+                    stopPrice = null,
+                    tif = TIF.GTC,
+                    ts = 0L
+                )
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,4 +28,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "CryptoTrader"
-include(":contracts", ":core", ":data", ":runtime", ":paperbroker", ":ui", ":mocks", ":tools", ":app")
+include(":contracts", ":core", ":data", ":runtime", ":paperbroker", ":livebroker", ":ui", ":mocks", ":tools", ":app")


### PR DESCRIPTION
## Summary
- implement a depth-aware paper broker that applies maker/taker fees, tracks balances with a deterministic clock, and exposes an order book update API
- add a live broker module with REST executor plus Binance and Coinbase adapters and regression tests
- build the execution coordinator, default policy engine, and ledger plumbing with accompanying unit coverage

## Testing
- ./gradlew --console=plain paperbroker:test livebroker:test runtime:test

------
https://chatgpt.com/codex/tasks/task_e_68e17620b8e48321a9931f69a6abbbb2