### PR TITLE
Add advanced policy modes and risk sizing capabilities

### DIFF
--- a/contracts/src/main/kotlin/com/kevin/cryptotrader/contracts/PolicyRisk.kt
+++ b/contracts/src/main/kotlin/com/kevin/cryptotrader/contracts/PolicyRisk.kt
@@ -4,6 +4,23 @@ data class NetPlan(
   val intents: List<Intent>,
 )
 
+enum class PolicyMode { PRIORITY, NETTING, PORTFOLIO_TARGET, VOTE }
+
+data class PolicyConfig(
+  val mode: PolicyMode = PolicyMode.NETTING,
+  val priority: List<String> = emptyList(),
+  val voteThreshold: Double = 0.5,
+  val strategyWeights: Map<String, Double> = emptyMap(),
+) {
+  fun weightFor(sourceId: String): Double {
+    if (strategyWeights.isEmpty()) return 1.0
+    val match = strategyWeights
+      .filterKeys { sourceId.startsWith(it) }
+      .maxByOrNull { it.key.length }
+    return match?.value ?: 0.0
+  }
+}
+
 interface PolicyEngine {
   fun net(
     intents: List<Intent>,
@@ -11,9 +28,37 @@ interface PolicyEngine {
   ): NetPlan
 }
 
+@kotlinx.serialization.Serializable
+enum class StopKind { ATR, TRAILING, TIME }
+
+@kotlinx.serialization.Serializable
+sealed class RiskEvent {
+  abstract val intentId: String
+  abstract val symbol: String
+  abstract val side: Side
+
+  @kotlinx.serialization.Serializable
+  data class StopSet(
+    override val intentId: String,
+    override val symbol: String,
+    override val side: Side,
+    val kind: StopKind,
+    val stopPrice: Double? = null,
+    val trailingPct: Double? = null,
+    val expiresAt: Long? = null,
+    val meta: Map<String, String> = emptyMap(),
+  ) : RiskEvent()
+}
+
+data class RiskResult(
+  val orders: List<Order>,
+  val stopOrders: List<Order> = emptyList(),
+  val events: List<RiskEvent> = emptyList(),
+)
+
 interface RiskSizer {
   fun size(
     plan: NetPlan,
     account: AccountSnapshot,
-  ): List<Order>
+  ): RiskResult
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 
   testImplementation(kotlin("test"))
   testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }
 
 tasks.test { useJUnitPlatform() }

--- a/core/src/main/kotlin/com/kevin/cryptotrader/core/policy/PolicyEngineImpl.kt
+++ b/core/src/main/kotlin/com/kevin/cryptotrader/core/policy/PolicyEngineImpl.kt
@@ -2,60 +2,231 @@ package com.kevin.cryptotrader.core.policy
 
 import com.kevin.cryptotrader.contracts.Intent
 import com.kevin.cryptotrader.contracts.NetPlan
+import com.kevin.cryptotrader.contracts.PolicyConfig
 import com.kevin.cryptotrader.contracts.PolicyEngine
+import com.kevin.cryptotrader.contracts.PolicyMode
 import com.kevin.cryptotrader.contracts.Position
 import com.kevin.cryptotrader.contracts.Side
+import kotlin.math.abs
 
 /**
- * Deterministic netting based on source priority and side cancellation.
- * - Keep intents from higher-priority sources when conflicts exist for the same symbol.
- * - Net opposing sides by qty if provided, else by notionalUsd when qty is null.
- * - Aggregate by (symbol, side) after netting.
+ * Policy engine supporting multiple conflict modes:
+ * - Priority: deterministic selection of intents from higher-ranked sources.
+ * - Netting: sums same-side intents before offsetting opposing directions.
+ * - Portfolio target: blends strategy targets with weights and current positions.
+ * - Vote: applies weighted voting with configurable thresholds.
  */
 class PolicyEngineImpl(
-  private val priority: List<String> = emptyList(),
+  private val config: PolicyConfig = PolicyConfig(),
 ) : PolicyEngine {
 
   override fun net(intents: List<Intent>, positions: List<Position>): NetPlan {
     if (intents.isEmpty()) return NetPlan(emptyList())
 
-    // Partition intents by symbol
-    val bySymbol = intents.groupBy { it.symbol }
-    val result = mutableListOf<Intent>()
+    val weightedIntents = intents.filter { config.weightFor(it.sourceId) > 0.0 }
+    if (weightedIntents.isEmpty()) return NetPlan(emptyList())
 
-    for ((symbol, group) in bySymbol) {
-      // When multiple sources conflict, keep highest-priority ones per side
-      val bestBySide = Side.values().associateWith { side ->
-        pickBest(group.filter { it.side == side })
-      }
-
-      val buy = bestBySide[Side.BUY]
-      val sell = bestBySide[Side.SELL]
-
-      val net = netOpposing(symbol, buy, sell)
-      result.addAll(net)
+    val planIntents = when (config.mode) {
+      PolicyMode.PRIORITY -> priorityNet(weightedIntents)
+      PolicyMode.NETTING -> netting(weightedIntents)
+      PolicyMode.PORTFOLIO_TARGET -> portfolioTarget(weightedIntents, positions)
+      PolicyMode.VOTE -> vote(weightedIntents, positions)
     }
 
-    // Aggregate by (symbol, side) to a single intent per pair
-    val aggregated = result.groupBy { it.symbol to it.side }.map { (k, list) ->
-      val first = list.first()
-      val totalQty = list.mapNotNull { it.qty }.takeIf { it.isNotEmpty() }?.sum()
-      val totalNotional = list.mapNotNull { it.notionalUsd }.takeIf { it.isNotEmpty() }?.sum()
-      first.copy(id = first.id, qty = totalQty, notionalUsd = totalNotional)
-    }
-
-    return NetPlan(aggregated)
+    return normalize(planIntents)
   }
 
   private fun pickBest(candidates: List<Intent>): Intent? {
     if (candidates.isEmpty()) return null
-    if (priority.isEmpty()) return candidates.first() // stable
+    if (config.priority.isEmpty()) return candidates.first()
     return candidates.minBy { sourceRank(it.sourceId) }
   }
 
   private fun sourceRank(sourceId: String): Int {
-    val idx = priority.indexOfFirst { prefix -> sourceId.startsWith(prefix) }
+    val idx = config.priority.indexOfFirst { prefix -> sourceId.startsWith(prefix) }
     return if (idx >= 0) idx else Int.MAX_VALUE
+  }
+
+  private fun priorityNet(intents: List<Intent>): List<Intent> {
+    val result = mutableListOf<Intent>()
+    intents.groupBy { it.symbol }.forEach { (symbol, group) ->
+      val buys = pickBest(group.filter { it.side == Side.BUY })
+      val sells = pickBest(group.filter { it.side == Side.SELL })
+      result.addAll(netOpposing(symbol, buys, sells))
+    }
+    return result
+  }
+
+  private fun netting(intents: List<Intent>): List<Intent> {
+    val result = mutableListOf<Intent>()
+    intents.groupBy { it.symbol }.forEach { (symbol, group) ->
+      val buys = aggregateSide(symbol, Side.BUY, group.filter { it.side == Side.BUY })
+      val sells = aggregateSide(symbol, Side.SELL, group.filter { it.side == Side.SELL })
+      result.addAll(netOpposing(symbol, buys, sells))
+    }
+    return result
+  }
+
+  private fun portfolioTarget(intents: List<Intent>, positions: List<Position>): List<Intent> {
+    if (intents.isEmpty()) return emptyList()
+    val currentBySymbol = positions.groupBy { it.symbol }.mapValues { entry ->
+      entry.value.sumOf { it.qty }
+    }
+    val results = mutableListOf<Intent>()
+
+    intents.groupBy { it.symbol }.forEach { (symbol, group) ->
+      val contributions = group.mapNotNull { intent ->
+        val target = extractTargetQty(intent)
+        val weight = config.weightFor(intent.sourceId)
+        if (target != null && weight > 0.0) WeightedTarget(target, weight, intent) else null
+      }
+      if (contributions.isEmpty()) return@forEach
+      val weightSum = contributions.sumOf { it.weight }
+      if (weightSum <= 0.0) return@forEach
+      val weightedTarget = contributions.sumOf { it.target * it.weight } / weightSum
+      val currentQty = currentBySymbol[symbol] ?: 0.0
+      val delta = weightedTarget - currentQty
+      if (abs(delta) <= EPS) return@forEach
+      val side = if (delta > 0) Side.BUY else Side.SELL
+      val qty = abs(delta)
+      val priceHint = contributions.mapNotNull { it.intent.priceHint }.firstOrNull()
+      results.add(
+        Intent(
+          id = "portfolio-${symbol.lowercase()}",
+          sourceId = "policy.portfolio",
+          kind = "portfolio_target",
+          symbol = symbol,
+          side = side,
+          qty = qty,
+          notionalUsd = priceHint?.let { it * qty },
+          priceHint = priceHint,
+          meta = mergeMeta(contributions.map { it.intent }),
+        ),
+      )
+    }
+
+    return results
+  }
+
+  private fun vote(intents: List<Intent>, positions: List<Position>): List<Intent> {
+    if (intents.isEmpty()) return emptyList()
+    val currentBySymbol = positions.groupBy { it.symbol }.mapValues { entry ->
+      entry.value.sumOf { it.qty }
+    }
+    val results = mutableListOf<Intent>()
+
+    intents.groupBy { it.symbol }.forEach { (symbol, group) ->
+      val contributions = group.map { WeightedIntent(config.weightFor(it.sourceId), it) }
+        .filter { it.weight > 0.0 }
+      if (contributions.isEmpty()) return@forEach
+      val totalWeight = contributions.sumOf { it.weight }
+      if (totalWeight <= 0.0) return@forEach
+
+      val buyWeight = contributions.filter { it.intent.side == Side.BUY }.sumOf { it.weight }
+      val sellWeight = contributions.filter { it.intent.side == Side.SELL }.sumOf { it.weight }
+      val thresholdWeight = totalWeight * config.voteThreshold.coerceIn(0.0, 1.0)
+
+      val winner = when {
+        buyWeight >= thresholdWeight && buyWeight > sellWeight -> Side.BUY
+        sellWeight >= thresholdWeight && sellWeight > buyWeight -> Side.SELL
+        else -> null
+      }
+      if (winner == null) return@forEach
+
+      val currentQty = currentBySymbol[symbol] ?: 0.0
+      val delta = computeVoteDelta(contributions, currentQty) ?: return@forEach
+      if (winner == Side.BUY && delta <= EPS) return@forEach
+      if (winner == Side.SELL && delta >= -EPS) return@forEach
+      val qty = abs(delta)
+      if (qty <= EPS) return@forEach
+
+      val priceHint = contributions.mapNotNull { it.intent.priceHint }.firstOrNull()
+      results.add(
+        Intent(
+          id = "vote-${symbol.lowercase()}",
+          sourceId = "policy.vote",
+          kind = "vote",
+          symbol = symbol,
+          side = winner,
+          qty = qty,
+          notionalUsd = priceHint?.let { it * qty },
+          priceHint = priceHint,
+          meta = mergeMeta(contributions.map { it.intent }),
+        ),
+      )
+    }
+
+    return results
+  }
+
+  private fun computeVoteDelta(contributions: List<WeightedIntent>, currentQty: Double): Double? {
+    val targets = contributions.mapNotNull { wi ->
+      extractTargetQty(wi.intent)?.let { wi.weight to it }
+    }
+    return if (targets.isNotEmpty()) {
+      val weightSum = targets.sumOf { it.first }
+      if (weightSum <= 0.0) {
+        null
+      } else {
+        (targets.sumOf { it.first * it.second } / weightSum) - currentQty
+      }
+    } else {
+      val weightSum = contributions.sumOf { it.weight }
+      if (weightSum <= 0.0) return null
+      contributions.sumOf { wi ->
+        val qty = resolveQty(wi.intent) ?: 0.0
+        val signed = if (wi.intent.side == Side.BUY) qty else -qty
+        signed * wi.weight
+      } / weightSum
+    }
+  }
+
+  private fun aggregateSide(symbol: String, side: Side, intents: List<Intent>): Intent? {
+    if (intents.isEmpty()) return null
+    val template = intents.first()
+    val totalQty = sumQty(intents)
+    val totalNotional = sumNotional(intents)
+    val priceHint = template.priceHint ?: intents.mapNotNull { it.priceHint }.firstOrNull()
+    return Intent(
+      id = "agg-${symbol.lowercase()}-${side.name.lowercase()}",
+      sourceId = template.sourceId,
+      kind = template.kind,
+      symbol = symbol,
+      side = side,
+      qty = totalQty,
+      notionalUsd = totalNotional,
+      priceHint = priceHint,
+      meta = template.meta,
+    )
+  }
+
+  private fun sumQty(intents: List<Intent>): Double? {
+    val values = intents.mapNotNull { it.qty }
+    return if (values.isEmpty()) null else values.sum()
+  }
+
+  private fun sumNotional(intents: List<Intent>): Double? {
+    val values = intents.mapNotNull { it.notionalUsd }
+    return if (values.isEmpty()) null else values.sum()
+  }
+
+  private fun normalize(intents: List<Intent>): NetPlan {
+    if (intents.isEmpty()) return NetPlan(emptyList())
+    val aggregated = intents.groupBy { it.symbol to it.side }.mapNotNull { (_, group) ->
+      val first = group.first()
+      val qty = sumQty(group)
+      val notional = sumNotional(group)
+      val effectiveQty = qty ?: notional?.let { n ->
+        val price = first.priceHint
+        if (price != null && price > 0) n / price else null
+      }
+      if ((effectiveQty ?: 0.0) <= EPS && (notional ?: 0.0) <= EPS) {
+        null
+      } else {
+        first.copy(qty = qty ?: effectiveQty, notionalUsd = notional)
+      }
+    }
+    return NetPlan(aggregated)
   }
 
   private fun netOpposing(symbol: String, buy: Intent?, sell: Intent?): List<Intent> {
@@ -63,25 +234,24 @@ class PolicyEngineImpl(
     if (buy == null) return listOf(sell!!)
     if (sell == null) return listOf(buy)
 
-    // Prefer qty-based netting when both have qty; else notionalUsd.
-    val bq = buy.qty
-    val sq = sell.qty
+    val bq = resolveQty(buy)
+    val sq = resolveQty(sell)
     if (bq != null && sq != null) {
       val diff = bq - sq
       return when {
-        diff > 0 -> listOf(buy.copy(qty = diff))
-        diff < 0 -> listOf(sell.copy(qty = -diff))
+        diff > EPS -> listOf(adjustQty(buy, diff))
+        diff < -EPS -> listOf(adjustQty(sell, -diff))
         else -> emptyList()
       }
     }
 
-    val bn = buy.notionalUsd
-    val sn = sell.notionalUsd
+    val bn = resolveNotional(buy)
+    val sn = resolveNotional(sell)
     if (bn != null && sn != null) {
       val diff = bn - sn
       return when {
-        diff > 0 -> listOf(buy.copy(notionalUsd = diff))
-        diff < 0 -> listOf(sell.copy(notionalUsd = -diff))
+        diff > EPS -> listOf(adjustNotional(buy, diff))
+        diff < -EPS -> listOf(adjustNotional(sell, -diff))
         else -> emptyList()
       }
     }
@@ -89,6 +259,66 @@ class PolicyEngineImpl(
     // If mixed (one qty, one notional) keep higher-priority one verbatim
     val keep = listOfNotNull(buy, sell).minBy { sourceRank(it.sourceId) }
     return listOf(keep)
+  }
+
+  private fun resolveQty(intent: Intent): Double? {
+    intent.qty?.let { return it }
+    val notional = intent.notionalUsd
+    val price = intent.priceHint
+    if (notional != null && price != null && price > 0) return notional / price
+    return null
+  }
+
+  private fun resolveNotional(intent: Intent): Double? {
+    intent.notionalUsd?.let { return it }
+    val qty = intent.qty
+    val price = intent.priceHint
+    if (qty != null && price != null) return qty * price
+    return null
+  }
+
+  private fun adjustQty(intent: Intent, qty: Double): Intent {
+    val price = intent.priceHint
+    val notional = if (price != null) qty * price else intent.notionalUsd
+    return intent.copy(qty = qty, notionalUsd = notional)
+  }
+
+  private fun adjustNotional(intent: Intent, notional: Double): Intent {
+    val price = intent.priceHint
+    val qty = if (price != null && price > 0) notional / price else intent.qty
+    return intent.copy(notionalUsd = notional, qty = qty)
+  }
+
+  private fun extractTargetQty(intent: Intent): Double? {
+    val meta = intent.meta
+    val keys = listOf(
+      "target_qty",
+      "targetQty",
+      "target_position",
+      "portfolio_target_qty",
+    )
+    val direct = keys.asSequence().mapNotNull { meta[it]?.toDoubleOrNull() }.firstOrNull()
+    if (direct != null) return direct
+    val targetNotional = meta["target_notional"]?.toDoubleOrNull()
+      ?: meta["target_notional_usd"]?.toDoubleOrNull()
+    val price = intent.priceHint
+    if (targetNotional != null && price != null && price > 0) return targetNotional / price
+    return null
+  }
+
+  private fun mergeMeta(intents: List<Intent>): Map<String, String> {
+    if (intents.isEmpty()) return emptyMap()
+    val merged = linkedMapOf<String, String>()
+    intents.forEach { merged.putAll(it.meta) }
+    return merged
+  }
+
+  private data class WeightedTarget(val target: Double, val weight: Double, val intent: Intent)
+
+  private data class WeightedIntent(val weight: Double, val intent: Intent)
+
+  companion object {
+    private const val EPS = 1e-9
   }
 }
 

--- a/core/src/main/kotlin/com/kevin/cryptotrader/core/policy/RiskSizerImpl.kt
+++ b/core/src/main/kotlin/com/kevin/cryptotrader/core/policy/RiskSizerImpl.kt
@@ -4,34 +4,318 @@ import com.kevin.cryptotrader.contracts.AccountSnapshot
 import com.kevin.cryptotrader.contracts.NetPlan
 import com.kevin.cryptotrader.contracts.Order
 import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.RiskEvent
+import com.kevin.cryptotrader.contracts.RiskResult
 import com.kevin.cryptotrader.contracts.RiskSizer
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.contracts.StopKind
+import com.kevin.cryptotrader.contracts.TIF
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
 /**
- * Simple, deterministic risk sizer:
- * - If qty provided, emit a MARKET order with that qty.
- * - Else if notionalUsd provided and priceHint present, qty = notionalUsd / priceHint.
- * - Else skip (un-sizable) — higher-level should surface an error.
- * No leverage or balance checks to keep it pure and testable.
+ * Risk sizing with deterministic outcomes across:
+ * - Fixed % of equity, ATR-scaled sizing, volatility targeting, and fixed-notional fallbacks.
+ * - ATR, trailing, and time-based stops emitting both orders and ledger-friendly events.
+ * - Global portfolio caps and symbol-level caps.
+ * - Correlation guard to prevent overlapping exposures in the same beta group.
  */
-class RiskSizerImpl : RiskSizer {
-  override fun size(plan: NetPlan, account: AccountSnapshot): List<Order> {
-    val out = mutableListOf<Order>()
-    plan.intents.forEach { intent ->
-      val qty = intent.qty ?: intent.notionalUsd?.let { n -> intent.priceHint?.let { p -> if (p > 0) n / p else null } }
-      if (qty != null && qty > 0.0) {
-        out.add(
+data class CorrelationGuardConfig(
+  val groups: List<Set<String>> = emptyList(),
+  val maxActivePerGroup: Int = Int.MAX_VALUE,
+)
+
+data class RiskSizerConfig(
+  val defaultRiskPct: Double = 0.01,
+  val maxPortfolioRiskPct: Double = 1.0,
+  val perSymbolCaps: Map<String, Double> = emptyMap(),
+  val correlationGuard: CorrelationGuardConfig = CorrelationGuardConfig(),
+  val clockMs: () -> Long = System::currentTimeMillis,
+)
+
+class RiskSizerImpl(
+  private val config: RiskSizerConfig = RiskSizerConfig(),
+) : RiskSizer {
+
+  override fun size(plan: NetPlan, account: AccountSnapshot): RiskResult {
+    val equity = account.equityUsd
+    if (plan.intents.isEmpty() || equity <= 0.0) return RiskResult(emptyList())
+
+    val entries = mutableListOf<Order>()
+    val stops = mutableListOf<Order>()
+    val events = mutableListOf<RiskEvent>()
+
+    val sortedIntents = plan.intents.sortedByDescending { resolveNotional(it) ?: 0.0 }
+    val groupUsage = mutableMapOf<Int, Int>()
+    val maxPortfolioUsd = max(0.0, equity * config.maxPortfolioRiskPct)
+    var usedUsd = 0.0
+
+    sortedIntents.forEach { intent ->
+      val price = resolvePrice(intent) ?: return@forEach
+      val meta = parseRiskMeta(intent)
+      val baseQty = computeQty(intent, price, equity, meta) ?: return@forEach
+      var qty = baseQty
+      if (qty <= EPS) return@forEach
+
+      var notional = qty * price
+
+      config.perSymbolCaps[intent.symbol]?.takeIf { it > 0 }?.let { capPct ->
+        val capUsd = equity * capPct
+        if (capUsd <= EPS) return@forEach
+        if (notional > capUsd) {
+          qty = capUsd / price
+          notional = qty * price
+        }
+      }
+
+      if (maxPortfolioUsd > EPS) {
+        val remaining = maxPortfolioUsd - usedUsd
+        if (remaining <= EPS) return@forEach
+        if (notional > remaining) {
+          qty = remaining / price
+          notional = qty * price
+        }
+      }
+
+      if (qty <= EPS || notional <= EPS) return@forEach
+
+      if (!passesCorrelationGuard(intent.symbol, groupUsage)) return@forEach
+
+      entries.add(
+        Order(
+          clientOrderId = "ord-${intent.id}",
+          symbol = intent.symbol,
+          side = intent.side,
+          type = OrderType.MARKET,
+          qty = qty,
+          price = null,
+        ),
+      )
+      usedUsd += notional
+
+      val stopArtifacts = buildStops(intent, qty, price, meta)
+      stops.addAll(stopArtifacts.orders)
+      events.addAll(stopArtifacts.events)
+    }
+
+    return RiskResult(entries, stops, events)
+  }
+
+  private fun resolvePrice(intent: com.kevin.cryptotrader.contracts.Intent): Double? {
+    val price = intent.priceHint
+    if (price != null && price > 0) return price
+    val qty = intent.qty
+    val notional = intent.notionalUsd
+    if (qty != null && qty > 0 && notional != null && notional > 0) return notional / qty
+    return null
+  }
+
+  private fun resolveNotional(intent: com.kevin.cryptotrader.contracts.Intent): Double? {
+    intent.notionalUsd?.let { return it }
+    val price = resolvePrice(intent)
+    val qty = intent.qty
+    if (price != null && qty != null) return qty * price
+    return null
+  }
+
+  private fun computeQty(
+    intent: com.kevin.cryptotrader.contracts.Intent,
+    price: Double,
+    equity: Double,
+    meta: RiskMeta,
+  ): Double? {
+    val qty = when (meta.mode) {
+      RiskMode.FIXED_NOTIONAL -> intent.qty ?: meta.notionalUsd?.let { it / price }
+        ?: resolveNotional(intent)?.let { it / price }
+      RiskMode.FIXED_PCT -> {
+        val pct = (meta.riskPct ?: config.defaultRiskPct).coerceAtLeast(0.0)
+        if (pct <= 0.0) return null
+        val capital = equity * pct
+        val stopDistance = stopDistance(meta)
+        val denom = if (stopDistance != null && stopDistance > EPS) stopDistance else price
+        if (denom <= EPS) return null
+        capital / denom
+      }
+      RiskMode.ATR -> {
+        val atr = meta.atr ?: return null
+        val mult = meta.atrMultiplier ?: 1.0
+        val distance = atr * mult
+        if (distance <= EPS) return null
+        val pct = (meta.riskPct ?: config.defaultRiskPct).coerceAtLeast(0.0)
+        if (pct <= 0.0) return null
+        val capital = equity * pct
+        capital / distance
+      }
+      RiskMode.VOL_TARGET -> {
+        val vol = meta.volatility ?: return null
+        val target = meta.targetVolatility ?: return null
+        if (vol <= EPS || target <= 0.0) return null
+        val pct = (meta.riskPct ?: config.defaultRiskPct).coerceAtLeast(0.0)
+        if (pct <= 0.0) return null
+        val exposureUsd = equity * pct * (target / vol)
+        if (price <= EPS) return null
+        exposureUsd / price
+      }
+    }
+    return qty?.coerceAtLeast(0.0)
+  }
+
+  private fun stopDistance(meta: RiskMeta): Double? {
+    val atr = meta.atr
+    val mult = meta.stopAtrMultiplier ?: meta.atrMultiplier
+    return if (atr != null && mult != null) atr * mult else null
+  }
+
+  private fun passesCorrelationGuard(symbol: String, usage: MutableMap<Int, Int>): Boolean {
+    if (config.correlationGuard.groups.isEmpty()) return true
+    var allowed = true
+    config.correlationGuard.groups.forEachIndexed { index, group ->
+      if (!group.contains(symbol)) return@forEachIndexed
+      val count = usage.getOrDefault(index, 0)
+      if (count >= config.correlationGuard.maxActivePerGroup) {
+        allowed = false
+        return@forEachIndexed
+      }
+    }
+    if (!allowed) return false
+    config.correlationGuard.groups.forEachIndexed { index, group ->
+      if (group.contains(symbol)) {
+        usage[index] = usage.getOrDefault(index, 0) + 1
+      }
+    }
+    return true
+  }
+
+  private fun buildStops(
+    intent: com.kevin.cryptotrader.contracts.Intent,
+    qty: Double,
+    price: Double,
+    meta: RiskMeta,
+  ): StopArtifacts {
+    val orders = mutableListOf<Order>()
+    val events = mutableListOf<RiskEvent>()
+    val stopDistance = stopDistance(meta)
+    val opposite = if (intent.side == Side.BUY) Side.SELL else Side.BUY
+
+    if (stopDistance != null && stopDistance > EPS) {
+      val stopPrice = if (intent.side == Side.BUY) price - stopDistance else price + stopDistance
+      if (stopPrice > EPS) {
+        orders.add(
           Order(
-            clientOrderId = "ord-${intent.id}",
+            clientOrderId = "stop-${intent.id}",
             symbol = intent.symbol,
-            side = intent.side,
-            type = OrderType.MARKET,
+            side = opposite,
+            type = OrderType.STOP,
             qty = qty,
             price = null,
+            stopPrice = stopPrice,
+            tif = TIF.GTC,
+          ),
+        )
+        events.add(
+          RiskEvent.StopSet(
+            intentId = intent.id,
+            symbol = intent.symbol,
+            side = opposite,
+            kind = StopKind.ATR,
+            stopPrice = stopPrice,
           ),
         )
       }
     }
-    return out
+
+    meta.trailingPct?.takeIf { it > 0 }?.let { pct ->
+      events.add(
+        RiskEvent.StopSet(
+          intentId = intent.id,
+          symbol = intent.symbol,
+          side = opposite,
+          kind = StopKind.TRAILING,
+          trailingPct = pct,
+        ),
+      )
+    }
+
+    meta.timeStopSec?.takeIf { it > 0 }?.let { seconds ->
+      val expiresAt = config.clockMs().plus(TimeUnit.SECONDS.toMillis(seconds))
+      events.add(
+        RiskEvent.StopSet(
+          intentId = intent.id,
+          symbol = intent.symbol,
+          side = opposite,
+          kind = StopKind.TIME,
+          expiresAt = expiresAt,
+        ),
+      )
+    }
+
+    return StopArtifacts(orders, events)
+  }
+
+  private fun parseRiskMeta(intent: com.kevin.cryptotrader.contracts.Intent): RiskMeta {
+    val meta = intent.meta
+    val modeKey = meta["risk.mode"]?.lowercase()
+    val mode = when (modeKey) {
+      "fixed_pct", "fixed%", "fixed-percent" -> RiskMode.FIXED_PCT
+      "atr" -> RiskMode.ATR
+      "vol_target", "volatility", "vol" -> RiskMode.VOL_TARGET
+      else -> when {
+        meta.containsKey("risk.pct") -> RiskMode.FIXED_PCT
+        meta.containsKey("risk.atr") || meta.containsKey("atr") -> RiskMode.ATR
+        meta.containsKey("risk.target_vol") || meta.containsKey("target_volatility") -> RiskMode.VOL_TARGET
+        else -> RiskMode.FIXED_NOTIONAL
+      }
+    }
+
+    val riskPct = meta["risk.pct"]?.toDoubleOrNull()
+    val notional = meta["risk.notional"]?.toDoubleOrNull()
+    val atr = meta["risk.atr"]?.toDoubleOrNull() ?: meta["atr"]?.toDoubleOrNull()
+    val atrMult = meta["risk.atr_mult"]?.toDoubleOrNull() ?: meta["atr_multiplier"]?.toDoubleOrNull()
+    val stopAtrMult = meta["stop.atr_mult"]?.toDoubleOrNull() ?: meta["stop.atr_multiplier"]?.toDoubleOrNull()
+    val trailingPct = meta["stop.trailing_pct"]?.toDoubleOrNull() ?: meta["trailing_pct"]?.toDoubleOrNull()
+    val timeStopSec = meta["stop.time_sec"]?.toLongOrNull()
+      ?: meta["stop.time_minutes"]?.toLongOrNull()?.let { it * 60 }
+      ?: meta["time_stop_sec"]?.toLongOrNull()
+    val volatility = meta["risk.vol"]?.toDoubleOrNull() ?: meta["volatility"]?.toDoubleOrNull()
+    val targetVolatility = meta["risk.target_vol"]?.toDoubleOrNull()
+      ?: meta["target_volatility"]?.toDoubleOrNull()
+
+    return RiskMeta(
+      mode = mode,
+      riskPct = riskPct,
+      notionalUsd = notional,
+      atr = atr,
+      atrMultiplier = atrMult,
+      stopAtrMultiplier = stopAtrMult,
+      trailingPct = trailingPct,
+      timeStopSec = timeStopSec,
+      volatility = volatility,
+      targetVolatility = targetVolatility,
+    )
+  }
+
+  private data class StopArtifacts(
+    val orders: List<Order>,
+    val events: List<RiskEvent>,
+  )
+
+  private data class RiskMeta(
+    val mode: RiskMode,
+    val riskPct: Double?,
+    val notionalUsd: Double?,
+    val atr: Double?,
+    val atrMultiplier: Double?,
+    val stopAtrMultiplier: Double?,
+    val trailingPct: Double?,
+    val timeStopSec: Long?,
+    val volatility: Double?,
+    val targetVolatility: Double?,
+  )
+
+  private enum class RiskMode { FIXED_NOTIONAL, FIXED_PCT, ATR, VOL_TARGET }
+
+  companion object {
+    private const val EPS = 1e-9
   }
 }
 

--- a/core/src/test/kotlin/com/kevin/cryptotrader/core/policy/PolicyRiskTest.kt
+++ b/core/src/test/kotlin/com/kevin/cryptotrader/core/policy/PolicyRiskTest.kt
@@ -1,58 +1,263 @@
 package com.kevin.cryptotrader.core.policy
 
-import com.kevin.cryptotrader.contracts.*
+import com.kevin.cryptotrader.contracts.AccountSnapshot
+import com.kevin.cryptotrader.contracts.Intent
+import com.kevin.cryptotrader.contracts.NetPlan
+import com.kevin.cryptotrader.contracts.OrderType
+import com.kevin.cryptotrader.contracts.PolicyConfig
+import com.kevin.cryptotrader.contracts.PolicyMode
+import com.kevin.cryptotrader.contracts.Position
+import com.kevin.cryptotrader.contracts.RiskEvent
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.contracts.StopKind
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 class PolicyRiskTest {
-  @Test
-  fun priority_netting_and_sizing() {
-    val priority = loadPriority()
-    val policy = PolicyEngineImpl(priority)
+  private val json = Json { ignoreUnknownKeys = true }
 
-    val intents = listOf(
-      Intent(id = "i1", sourceId = "automation.dca#1", kind = "sig", symbol = "BTCUSDT", side = Side.BUY, qty = 0.1, priceHint = 20000.0),
-      Intent(id = "i2", sourceId = "strategy.momentum#main", kind = "sig", symbol = "BTCUSDT", side = Side.SELL, qty = 0.05, priceHint = 20000.0),
-      Intent(id = "i3", sourceId = "strategy.momentum#main", kind = "sig", symbol = "BTCUSDT", side = Side.BUY, qty = 0.12, priceHint = 20000.0),
+  @Test
+  fun priorityFixtureNetsConflicts() {
+    val fixture = loadPolicyFixture("priority.json")
+    val policy = PolicyEngineImpl(fixture.toConfig())
+    val net = policy.net(fixture.intentObjects(), fixture.positionObjects())
+    assertMatches(fixture.expected, net.intents)
+  }
+
+  @Test
+  fun portfolioTargetFixtureRespectsTargets() {
+    val fixture = loadPolicyFixture("portfolio_target.json")
+    val policy = PolicyEngineImpl(fixture.toConfig())
+    val net = policy.net(fixture.intentObjects(), fixture.positionObjects())
+    assertMatches(fixture.expected, net.intents)
+  }
+
+  @Test
+  fun voteFixtureRequiresMajorityThreshold() {
+    val fixture = loadPolicyFixture("vote.json")
+    val policy = PolicyEngineImpl(fixture.toConfig())
+    val net = policy.net(fixture.intentObjects(), fixture.positionObjects())
+    assertMatches(fixture.expected, net.intents)
+  }
+
+  @Test
+  fun riskSizerFixedPercentAtrStop() {
+    val plan = NetPlan(
+      listOf(
+        Intent(
+          id = "risk-1",
+          sourceId = "strategy.momentum#main",
+          kind = "sig",
+          symbol = "BTCUSDT",
+          side = Side.BUY,
+          qty = null,
+          notionalUsd = null,
+          priceHint = 2000.0,
+          meta = mapOf(
+            "risk.mode" to "fixed_pct",
+            "risk.pct" to "0.02",
+            "risk.atr" to "100",
+            "stop.atr_mult" to "2",
+          ),
+        ),
+      ),
+    )
+    val sizer = RiskSizerImpl()
+    val result = sizer.size(plan, AccountSnapshot(equityUsd = 10_000.0, balances = emptyMap()))
+
+    assertEquals(1, result.orders.size)
+    val order = result.orders.first()
+    assertEquals(Side.BUY, order.side)
+    assertEquals(OrderType.MARKET, order.type)
+    assertApprox(1.0, order.qty)
+
+    assertEquals(1, result.stopOrders.size)
+    val stop = result.stopOrders.first()
+    assertEquals(Side.SELL, stop.side)
+    assertEquals(OrderType.STOP, stop.type)
+    assertApprox(1.0, stop.qty)
+    assertApprox(1800.0, stop.stopPrice!!)
+
+    assertTrue(result.events.any { ev ->
+      ev is RiskEvent.StopSet && ev.kind == StopKind.ATR &&
+        abs((ev.stopPrice ?: 0.0) - 1800.0) < 1e-6
+    })
+  }
+
+  @Test
+  fun riskSizerVolTargetCapsAndCorrelationGuard() {
+    val config = RiskSizerConfig(
+      defaultRiskPct = 0.02,
+      maxPortfolioRiskPct = 0.03,
+      perSymbolCaps = mapOf("BTCUSDT" to 0.015),
+      correlationGuard = CorrelationGuardConfig(
+        groups = listOf(setOf("BTCUSDT", "ETHUSDT")),
+        maxActivePerGroup = 1,
+      ),
+      clockMs = { 1_000L },
+    )
+    val sizer = RiskSizerImpl(config)
+    val plan = NetPlan(
+      listOf(
+        Intent(
+          id = "a",
+          sourceId = "strategy.vol#1",
+          kind = "sig",
+          symbol = "BTCUSDT",
+          side = Side.BUY,
+          priceHint = 100.0,
+          meta = mapOf(
+            "risk.mode" to "vol_target",
+            "risk.vol" to "0.1",
+            "risk.target_vol" to "0.2",
+            "risk.pct" to "0.02",
+            "stop.trailing_pct" to "0.05",
+            "stop.time_sec" to "3600",
+          ),
+        ),
+        Intent(
+          id = "b",
+          sourceId = "strategy.other#1",
+          kind = "sig",
+          symbol = "ETHUSDT",
+          side = Side.BUY,
+          priceHint = 200.0,
+          meta = mapOf(
+            "risk.mode" to "vol_target",
+            "risk.vol" to "0.12",
+            "risk.target_vol" to "0.24",
+          ),
+        ),
+      ),
     )
 
-    val net = policy.net(intents, positions = emptyList())
-    // Sell and buy from same high-priority source should net; buy wins with 0.07
-    assertEquals(1, net.intents.size)
-    val only = net.intents.first()
-    assertEquals(Side.BUY, only.side)
-    assertEquals("BTCUSDT", only.symbol)
-    assertTrue((only.qty ?: 0.0) > 0.069 && (only.qty ?: 0.0) < 0.071)
+    val result = sizer.size(plan, AccountSnapshot(equityUsd = 50_000.0, balances = emptyMap()))
 
-    val sizer = RiskSizerImpl()
-    val orders = sizer.size(net, AccountSnapshot(0.0, emptyMap()))
-    assertEquals(1, orders.size)
-    assertEquals(OrderType.MARKET, orders.first().type)
+    assertEquals(1, result.orders.size, "Correlation guard should skip the second intent")
+    val order = result.orders.first()
+    assertApprox(7.5, order.qty)
+    assertEquals("BTCUSDT", order.symbol)
+
+    assertTrue(result.stopOrders.isEmpty())
+    val trailing = result.events.firstOrNull { it is RiskEvent.StopSet && it.kind == StopKind.TRAILING }
+    assertTrue(trailing is RiskEvent.StopSet && abs((trailing.trailingPct ?: 0.0) - 0.05) < 1e-6)
+    val timeStop = result.events.firstOrNull { it is RiskEvent.StopSet && it.kind == StopKind.TIME }
+    assertTrue(timeStop is RiskEvent.StopSet && timeStop.expiresAt == 3_601_000L)
   }
 
-  private fun loadPriority(): List<String> {
-    val path = resolvePath("fixtures/policies/priority.json")
-    val json = Files.readString(path)
-    val lines = json.lines().map { it.trim() }
-    val start = lines.indexOfFirst { it.startsWith("\"priority\"") }
-    if (start < 0) return emptyList()
-    val arr = mutableListOf<String>()
-    var i = start
-    while (i < lines.size) {
-      val ln = lines[i]
-      if (ln.contains("[")) { i++; continue }
-      if (ln.contains("]")) break
-      val v = ln.trim().trim(',').trim().trim('"')
-      if (v.isNotEmpty()) arr.add(v)
-      i++
+  private fun assertMatches(expected: List<ExpectedIntent>, actual: List<Intent>) {
+    assertEquals(expected.size, actual.size, "Unexpected number of intents: $actual")
+    expected.forEach { exp ->
+      val match = actual.firstOrNull { it.symbol == exp.symbol && it.side == exp.sideEnum }
+        ?: fail("No intent for ${exp.symbol} ${exp.side}")
+      exp.qty?.let { assertApprox(it, match.qty ?: 0.0) }
+      exp.priceHint?.let { assertApprox(it, match.priceHint ?: 0.0) }
     }
-    return arr
   }
 
-  private fun resolvePath(path: String): java.nio.file.Path {
+  private fun assertApprox(expected: Double, actual: Double, tolerance: Double = 1e-6) {
+    assertTrue(abs(expected - actual) <= tolerance, "Expected $expected but was $actual")
+  }
+
+  private fun loadPolicyFixture(name: String): PolicyFixture {
+    val path = resolvePath("fixtures/policies/$name")
+    val root = Json.parseToJsonElement(Files.readString(path)).jsonObject
+    return PolicyFixture(
+      mode = root.string("mode") ?: error("mode required"),
+      priority = root.stringList("priority"),
+      strategyWeights = root.obj("strategyWeights")?.entries?.associate { entry ->
+        entry.key to (entry.value.jsonPrimitive.doubleOrNull ?: 0.0)
+      } ?: emptyMap(),
+      voteThreshold = root.double("voteThreshold"),
+      positions = root.array("positions").map { it.toFixturePosition() },
+      intents = root.array("intents").map { it.toFixtureIntent() },
+      expected = root.array("expected").map { it.toExpectedIntent() },
+    )
+  }
+
+  private fun PolicyFixture.intentObjects(): List<Intent> = intents.map { it.toIntent() }
+
+  private fun PolicyFixture.positionObjects(): List<Position> = positions.map { it.toPosition() }
+
+  private fun PolicyFixture.toConfig(): PolicyConfig = PolicyConfig(
+    mode = PolicyMode.valueOf(mode.uppercase().replace('-', '_')),
+    priority = priority,
+    voteThreshold = voteThreshold ?: 0.5,
+    strategyWeights = strategyWeights,
+  )
+
+  private data class PolicyFixture(
+    val mode: String,
+    val priority: List<String> = emptyList(),
+    val strategyWeights: Map<String, Double> = emptyMap(),
+    val voteThreshold: Double? = null,
+    val positions: List<FixturePosition> = emptyList(),
+    val intents: List<FixtureIntent>,
+    val expected: List<ExpectedIntent> = emptyList(),
+  )
+
+  private data class FixtureIntent(
+    val id: String,
+    val sourceId: String,
+    val kind: String,
+    val symbol: String,
+    val side: String,
+    val qty: Double? = null,
+    val notionalUsd: Double? = null,
+    val priceHint: Double? = null,
+    val meta: Map<String, String> = emptyMap(),
+  ) {
+    fun toIntent(): Intent = Intent(
+      id = id,
+      sourceId = sourceId,
+      kind = kind,
+      symbol = symbol,
+      side = Side.valueOf(side.uppercase()),
+      qty = qty,
+      notionalUsd = notionalUsd,
+      priceHint = priceHint,
+      meta = meta,
+    )
+  }
+
+  private data class FixturePosition(
+    val accountId: String = "acc",
+    val symbol: String,
+    val qty: Double,
+    val avgPrice: Double,
+  ) {
+    fun toPosition(): Position = Position(
+      accountId = accountId,
+      symbol = symbol,
+      qty = qty,
+      avgPrice = avgPrice,
+      realizedPnl = 0.0,
+      unrealizedPnl = 0.0,
+    )
+  }
+
+  private data class ExpectedIntent(
+    val symbol: String,
+    val side: String,
+    val qty: Double? = null,
+    val priceHint: Double? = null,
+  ) {
+    val sideEnum: Side get() = Side.valueOf(side.uppercase())
+  }
+
+  private fun resolvePath(path: String): Path {
     val candidates = listOf(
       Paths.get(path),
       Paths.get("../$path"),
@@ -61,5 +266,42 @@ class PolicyRiskTest {
     )
     return candidates.firstOrNull { Files.exists(it) } ?: error("Fixture not found: $path")
   }
-}
 
+  private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.content
+
+  private fun JsonObject.double(key: String): Double? = this[key]?.jsonPrimitive?.doubleOrNull
+
+  private fun JsonObject.stringList(key: String): List<String> =
+    this[key]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+
+  private fun JsonObject.array(key: String): List<JsonObject> =
+    this[key]?.jsonArray?.map { it.jsonObject } ?: emptyList()
+
+  private fun JsonObject.obj(key: String): JsonObject? = this[key]?.jsonObject
+
+  private fun JsonObject.toFixtureIntent(): FixtureIntent = FixtureIntent(
+    id = string("id") ?: error("intent id missing"),
+    sourceId = string("sourceId") ?: error("sourceId missing"),
+    kind = string("kind") ?: "sig",
+    symbol = string("symbol") ?: error("symbol missing"),
+    side = string("side") ?: error("side missing"),
+    qty = double("qty"),
+    notionalUsd = double("notionalUsd"),
+    priceHint = double("priceHint"),
+    meta = obj("meta")?.entries?.associate { it.key to it.value.jsonPrimitive.content } ?: emptyMap(),
+  )
+
+  private fun JsonObject.toFixturePosition(): FixturePosition = FixturePosition(
+    accountId = string("accountId") ?: "acc",
+    symbol = string("symbol") ?: error("position symbol missing"),
+    qty = double("qty") ?: 0.0,
+    avgPrice = double("avgPrice") ?: 0.0,
+  )
+
+  private fun JsonObject.toExpectedIntent(): ExpectedIntent = ExpectedIntent(
+    symbol = string("symbol") ?: error("expected symbol"),
+    side = string("side") ?: error("expected side"),
+    qty = double("qty"),
+    priceHint = double("priceHint"),
+  )
+}

--- a/fixtures/policies/portfolio_target.json
+++ b/fixtures/policies/portfolio_target.json
@@ -1,0 +1,53 @@
+{
+  "mode": "portfolio_target",
+  "strategyWeights": {
+    "strategy.momentum": 0.6,
+    "strategy.value": 0.4
+  },
+  "positions": [
+    { "accountId": "acc", "symbol": "BTCUSDT", "qty": 0.2, "avgPrice": 20000.0 },
+    { "accountId": "acc", "symbol": "ETHUSDT", "qty": 5.0, "avgPrice": 1500.0 }
+  ],
+  "intents": [
+    {
+      "id": "m1",
+      "sourceId": "strategy.momentum#main",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "BUY",
+      "priceHint": 21000.0,
+      "meta": { "target_qty": "0.8" }
+    },
+    {
+      "id": "v1",
+      "sourceId": "strategy.value#rot",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "SELL",
+      "priceHint": 21000.0,
+      "meta": { "target_qty": "0.4" }
+    },
+    {
+      "id": "m2",
+      "sourceId": "strategy.momentum#main",
+      "kind": "sig",
+      "symbol": "ETHUSDT",
+      "side": "BUY",
+      "priceHint": 1600.0,
+      "meta": { "target_qty": "4.0" }
+    },
+    {
+      "id": "v2",
+      "sourceId": "strategy.value#rot",
+      "kind": "sig",
+      "symbol": "ETHUSDT",
+      "side": "SELL",
+      "priceHint": 1600.0,
+      "meta": { "target_qty": "1.0" }
+    }
+  ],
+  "expected": [
+    { "symbol": "BTCUSDT", "side": "BUY", "qty": 0.44, "priceHint": 21000.0 },
+    { "symbol": "ETHUSDT", "side": "SELL", "qty": 2.2, "priceHint": 1600.0 }
+  ]
+}

--- a/fixtures/policies/priority.json
+++ b/fixtures/policies/priority.json
@@ -3,5 +3,42 @@
   "priority": [
     "strategy.momentum",
     "automation.dca"
+  ],
+  "intents": [
+    {
+      "id": "i1",
+      "sourceId": "automation.dca#1",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "BUY",
+      "qty": 0.1,
+      "priceHint": 20000.0
+    },
+    {
+      "id": "i2",
+      "sourceId": "strategy.momentum#main",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "SELL",
+      "qty": 0.05,
+      "priceHint": 20000.0
+    },
+    {
+      "id": "i3",
+      "sourceId": "strategy.momentum#main",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "BUY",
+      "qty": 0.12,
+      "priceHint": 20000.0
+    }
+  ],
+  "expected": [
+    {
+      "symbol": "BTCUSDT",
+      "side": "BUY",
+      "qty": 0.07,
+      "priceHint": 20000.0
+    }
   ]
 }

--- a/fixtures/policies/vote.json
+++ b/fixtures/policies/vote.json
@@ -1,0 +1,47 @@
+{
+  "mode": "vote",
+  "voteThreshold": 0.6,
+  "strategyWeights": {
+    "strategy.momentum": 0.5,
+    "strategy.meanrev": 0.3,
+    "automation.rebalance": 0.2
+  },
+  "positions": [
+    { "accountId": "acc", "symbol": "BTCUSDT", "qty": 0.3, "avgPrice": 20000.0 }
+  ],
+  "intents": [
+    {
+      "id": "m",
+      "sourceId": "strategy.momentum#main",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "BUY",
+      "qty": 0.4,
+      "priceHint": 20000.0,
+      "meta": { "target_qty": "0.7" }
+    },
+    {
+      "id": "r",
+      "sourceId": "automation.rebalance#1",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "BUY",
+      "qty": 0.3,
+      "priceHint": 20000.0,
+      "meta": { "target_qty": "0.5" }
+    },
+    {
+      "id": "mean",
+      "sourceId": "strategy.meanrev#alt",
+      "kind": "sig",
+      "symbol": "BTCUSDT",
+      "side": "SELL",
+      "qty": 0.2,
+      "priceHint": 20000.0,
+      "meta": { "target_qty": "0.0" }
+    }
+  ],
+  "expected": [
+    { "symbol": "BTCUSDT", "side": "BUY", "qty": 0.15, "priceHint": 20000.0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce PolicyConfig, PolicyMode, RiskResult, and RiskEvent contracts to support richer policy and risk flows
- extend PolicyEngineImpl with weighted priority, netting, portfolio-target, and vote modes plus fixtures-driven tests
- implement advanced RiskSizer with fixed %, ATR, volatility targeting, stops, caps, correlation guard, and update the backtester to consume the richer output

## Testing
- ./gradlew core:test

------
https://chatgpt.com/codex/tasks/task_e_68e17ac2377083219ba46ed6a9392056