### PR TITLE
Add built-in strategy fixtures and deterministic backtests

### DIFF
--- a/fixtures/strategies/bollinger.json
+++ b/fixtures/strategies/bollinger.json
@@ -1,0 +1,62 @@
+{
+  "id": "strategy_bollinger",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "bb_mid", "type": "BOLLINGER_MIDDLE", "period": 20, "symbol": "BTCUSDT", "params": {"k": 2.0}},
+    {"name": "bb_upper", "type": "BOLLINGER_UPPER", "period": 20, "symbol": "BTCUSDT", "params": {"k": 2.0}},
+    {"name": "bb_lower", "type": "BOLLINGER_LOWER", "period": 20, "symbol": "BTCUSDT", "params": {"k": 2.0}}
+  ],
+  "rules": [
+    {
+      "id": "bb_long",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "close"},
+        "dir": "ABOVE",
+        "right": {"type": "series", "name": "bb_lower"}
+      },
+      "actions": [
+        {
+          "type": "emitOrder",
+          "symbol": "BTCUSDT",
+          "side": "BUY",
+          "kind": "entry",
+          "price": {"type": "series", "name": "close"},
+          "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.012"}
+        },
+        {"type": "trailStop", "symbol": "BTCUSDT", "side": "SELL", "trailPct": 1.5, "kind": "stop"}
+      ],
+      "quota": {"max": 60, "windowMs": 86400000}
+    },
+    {
+      "id": "bb_short",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "close"},
+        "dir": "BELOW",
+        "right": {"type": "series", "name": "bb_upper"}
+      },
+      "actions": [
+        {
+          "type": "emitOrder",
+          "symbol": "BTCUSDT",
+          "side": "SELL",
+          "kind": "entry",
+          "price": {"type": "series", "name": "close"},
+          "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.012"}
+        },
+        {"type": "trailStop", "symbol": "BTCUSDT", "side": "BUY", "trailPct": 1.5, "kind": "stop"}
+      ],
+      "quota": {"max": 60, "windowMs": 86400000}
+    }
+  ]
+}

--- a/fixtures/strategies/dca.json
+++ b/fixtures/strategies/dca.json
@@ -1,0 +1,21 @@
+{
+  "id": "strategy_dca",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [],
+  "rules": [
+    {
+      "id": "dca_weekly",
+      "event": {"type": "schedule", "everyMs": 604800000},
+      "guard": {"type": "always"},
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "BUY", "kind": "dca", "price": {"type": "series", "name": "close"}, "notionalUsd": {"type": "const", "value": 250.0}, "metaStrings": {"risk.mode": "fixed_notional"}},
+        {"type": "notify", "channel": "dca", "message": "Weekly DCA executed", "severity": "info", "fields": {"price": {"type": "series", "name": "close"}}}
+      ]
+    }
+  ]
+}

--- a/fixtures/strategies/donchian.json
+++ b/fixtures/strategies/donchian.json
@@ -1,0 +1,45 @@
+{
+  "id": "strategy_donchian",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "dc_upper", "type": "DONCHIAN_UPPER", "period": 20, "symbol": "BTCUSDT"},
+    {"name": "dc_lower", "type": "DONCHIAN_LOWER", "period": 20, "symbol": "BTCUSDT"}
+  ],
+  "rules": [
+    {
+      "id": "donchian_long",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "close"},
+        "dir": "ABOVE",
+        "right": {"type": "series", "name": "dc_upper"}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "BUY", "kind": "entry", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.008"}}
+      ],
+      "quota": {"max": 40, "windowMs": 86400000}
+    },
+    {
+      "id": "donchian_short",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "close"},
+        "dir": "BELOW",
+        "right": {"type": "series", "name": "dc_lower"}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "SELL", "kind": "entry", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.008"}}
+      ],
+      "quota": {"max": 40, "windowMs": 86400000}
+    }
+  ]
+}

--- a/fixtures/strategies/ema.json
+++ b/fixtures/strategies/ema.json
@@ -1,0 +1,76 @@
+{
+  "id": "strategy_ema_cross",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "ema_fast", "type": "EMA", "period": 12, "source": "CLOSE", "symbol": "BTCUSDT"},
+    {"name": "ema_slow", "type": "EMA", "period": 26, "source": "CLOSE", "symbol": "BTCUSDT"},
+    {"name": "atr14", "type": "ATR", "period": 14, "symbol": "BTCUSDT"}
+  ],
+  "rules": [
+    {
+      "id": "ema_long",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "ema_fast"},
+        "dir": "ABOVE",
+        "right": {"type": "series", "name": "ema_slow"}
+      },
+      "actions": [
+        {
+          "type": "emitOrder",
+          "symbol": "BTCUSDT",
+          "side": "BUY",
+          "kind": "entry",
+          "price": {"type": "series", "name": "close"},
+          "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.01"}
+        },
+        {
+          "type": "setStopAtr",
+          "symbol": "BTCUSDT",
+          "side": "SELL",
+          "atrSeries": "atr14",
+          "multiplier": 2.0,
+          "kind": "stop"
+        }
+      ],
+      "quota": {"max": 100, "windowMs": 86400000}
+    },
+    {
+      "id": "ema_short",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "ema_fast"},
+        "dir": "BELOW",
+        "right": {"type": "series", "name": "ema_slow"}
+      },
+      "actions": [
+        {
+          "type": "emitOrder",
+          "symbol": "BTCUSDT",
+          "side": "SELL",
+          "kind": "entry",
+          "price": {"type": "series", "name": "close"},
+          "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.01"}
+        },
+        {
+          "type": "setStopAtr",
+          "symbol": "BTCUSDT",
+          "side": "BUY",
+          "atrSeries": "atr14",
+          "multiplier": 2.0,
+          "kind": "stop"
+        }
+      ],
+      "quota": {"max": 100, "windowMs": 86400000}
+    }
+  ]
+}

--- a/fixtures/strategies/grid.json
+++ b/fixtures/strategies/grid.json
@@ -1,0 +1,53 @@
+{
+  "id": "strategy_grid",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [],
+  "rules": [
+    {
+      "id": "grid_seed",
+      "event": {"type": "schedule", "everyMs": 43200000},
+      "guard": {"type": "always"},
+      "actions": [
+        {"type": "setState", "key": "grid.step", "value": {"type": "const", "value": 150.0}},
+        {"type": "setState", "key": "grid.center", "value": {"type": "series", "name": "close"}},
+        {"type": "setState", "key": "grid.lower", "value": {"type": "math", "op": "SUB", "left": {"type": "state", "key": "grid.center"}, "right": {"type": "state", "key": "grid.step"}}},
+        {"type": "setState", "key": "grid.upper", "value": {"type": "math", "op": "ADD", "left": {"type": "state", "key": "grid.center"}, "right": {"type": "state", "key": "grid.step"}}}
+      ]
+    },
+    {
+      "id": "grid_buy",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "threshold",
+        "left": {"type": "series", "name": "close"},
+        "op": "LTE",
+        "right": {"type": "state", "key": "grid.lower", "default": 0.0}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "BUY", "kind": "grid", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.005"}},
+        {"type": "incState", "key": "grid.lower", "delta": {"type": "state", "key": "grid.step", "default": 0.0}},
+        {"type": "incState", "key": "grid.upper", "delta": {"type": "state", "key": "grid.step", "default": 0.0}}
+      ]
+    },
+    {
+      "id": "grid_sell",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "threshold",
+        "left": {"type": "series", "name": "close"},
+        "op": "GTE",
+        "right": {"type": "state", "key": "grid.upper", "default": 0.0}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "SELL", "kind": "grid", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.005"}},
+        {"type": "incState", "key": "grid.upper", "delta": {"type": "math", "op": "SUB", "left": {"type": "const", "value": 0.0}, "right": {"type": "state", "key": "grid.step", "default": 0.0}}},
+        {"type": "incState", "key": "grid.lower", "delta": {"type": "math", "op": "SUB", "left": {"type": "const", "value": 0.0}, "right": {"type": "state", "key": "grid.step", "default": 0.0}}}
+      ]
+    }
+  ]
+}

--- a/fixtures/strategies/macd.json
+++ b/fixtures/strategies/macd.json
@@ -1,0 +1,41 @@
+{
+  "id": "strategy_macd",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "macd_line", "type": "MACD", "symbol": "BTCUSDT", "params": {"fast": 12.0, "slow": 26.0, "signal": 9.0}},
+    {"name": "macd_signal", "type": "MACD_SIGNAL", "symbol": "BTCUSDT", "params": {"fast": 12.0, "slow": 26.0, "signal": 9.0}}
+  ],
+  "rules": [
+    {
+      "id": "macd_long",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "macd_line"},
+        "dir": "ABOVE",
+        "right": {"type": "series", "name": "macd_signal"}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "BUY", "kind": "entry", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.01"}}
+      ]
+    },
+    {
+      "id": "macd_short",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "macd_line"},
+        "dir": "BELOW",
+        "right": {"type": "series", "name": "macd_signal"}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "SELL", "kind": "entry", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.01"}}
+      ]
+    }
+  ]
+}

--- a/fixtures/strategies/pair_ratio.json
+++ b/fixtures/strategies/pair_ratio.json
@@ -1,0 +1,41 @@
+{
+  "id": "strategy_pair_ratio",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"},
+    {"symbol": "ETHUSDT", "csvPath": "fixtures/ohlcv/ETHUSDT_1h_sample.csv"}
+  ],
+  "series": [],
+  "rules": [
+    {
+      "id": "ratio_high",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "math", "op": "DIV", "left": {"type": "series", "name": "close:BTCUSDT"}, "right": {"type": "series", "name": "close:ETHUSDT"}},
+        "dir": "ABOVE",
+        "right": {"type": "const", "value": 16.0}
+      },
+      "actions": [
+        {"type": "emitSpread", "symbol": "BTCUSDT", "side": "SELL", "offsetPct": 0.4, "widthPct": 0.8, "kind": "pair", "metaStrings": {"hedge": "ETHUSDT"}},
+        {"type": "emitOrder", "symbol": "ETHUSDT", "side": "BUY", "kind": "pair", "price": {"type": "series", "name": "close:ETHUSDT"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.01"}}
+      ]
+    },
+    {
+      "id": "ratio_low",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "math", "op": "DIV", "left": {"type": "series", "name": "close:BTCUSDT"}, "right": {"type": "series", "name": "close:ETHUSDT"}},
+        "dir": "BELOW",
+        "right": {"type": "const", "value": 14.0}
+      },
+      "actions": [
+        {"type": "emitSpread", "symbol": "BTCUSDT", "side": "BUY", "offsetPct": 0.4, "widthPct": 0.8, "kind": "pair", "metaStrings": {"hedge": "ETHUSDT"}},
+        {"type": "emitOrder", "symbol": "ETHUSDT", "side": "SELL", "kind": "pair", "price": {"type": "series", "name": "close:ETHUSDT"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.01"}}
+      ]
+    }
+  ]
+}

--- a/fixtures/strategies/rotation.json
+++ b/fixtures/strategies/rotation.json
@@ -1,0 +1,46 @@
+{
+  "id": "strategy_rotation",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"},
+    {"symbol": "ETHUSDT", "csvPath": "fixtures/ohlcv/ETHUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "roc_btc", "type": "ROC", "period": 24, "symbol": "BTCUSDT"},
+    {"name": "roc_eth", "type": "ROC", "period": 24, "symbol": "ETHUSDT"}
+  ],
+  "rules": [
+    {
+      "id": "rotate_btc",
+      "event": {"type": "schedule", "everyMs": 86400000},
+      "guard": {
+        "type": "threshold",
+        "left": {"type": "series", "name": "roc_btc"},
+        "op": "GT",
+        "right": {"type": "series", "name": "roc_eth"}
+      },
+      "actions": [
+        {"type": "log", "message": "Rotation favoring BTC", "fields": {"roc_btc": {"type": "series", "name": "roc_btc"}, "roc_eth": {"type": "series", "name": "roc_eth"}}},
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "BUY", "kind": "rotation", "price": {"type": "series", "name": "close:BTCUSDT"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.02"}},
+        {"type": "emitOrder", "symbol": "ETHUSDT", "side": "SELL", "kind": "rotation", "price": {"type": "series", "name": "close:ETHUSDT"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.02"}}
+      ]
+    },
+    {
+      "id": "rotate_eth",
+      "event": {"type": "schedule", "everyMs": 86400000},
+      "guard": {
+        "type": "threshold",
+        "left": {"type": "series", "name": "roc_eth"},
+        "op": "GT",
+        "right": {"type": "series", "name": "roc_btc"}
+      },
+      "actions": [
+        {"type": "log", "message": "Rotation favoring ETH", "fields": {"roc_btc": {"type": "series", "name": "roc_btc"}, "roc_eth": {"type": "series", "name": "roc_eth"}}},
+        {"type": "emitOrder", "symbol": "ETHUSDT", "side": "BUY", "kind": "rotation", "price": {"type": "series", "name": "close:ETHUSDT"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.02"}},
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "SELL", "kind": "rotation", "price": {"type": "series", "name": "close:BTCUSDT"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.02"}}
+      ]
+    }
+  ]
+}

--- a/fixtures/strategies/rsi.json
+++ b/fixtures/strategies/rsi.json
@@ -1,0 +1,71 @@
+{
+  "id": "strategy_rsi",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "rsi14", "type": "RSI", "period": 14, "source": "CLOSE", "symbol": "BTCUSDT"}
+  ],
+  "rules": [
+    {
+      "id": "rsi_long",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "rsi14"},
+        "dir": "ABOVE",
+        "right": {"type": "const", "value": 30.0}
+      },
+      "actions": [
+        {
+          "type": "emitOrder",
+          "symbol": "BTCUSDT",
+          "side": "BUY",
+          "kind": "entry",
+          "price": {"type": "series", "name": "close"},
+          "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.015"}
+        },
+        {
+          "type": "log",
+          "message": "RSI long triggered",
+          "level": "INFO",
+          "fields": {"rsi": {"type": "series", "name": "rsi14"}}
+        }
+      ],
+      "quota": {"max": 50, "windowMs": 86400000}
+    },
+    {
+      "id": "rsi_short",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "oncePerBar": true,
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "rsi14"},
+        "dir": "BELOW",
+        "right": {"type": "const", "value": 70.0}
+      },
+      "actions": [
+        {
+          "type": "emitOrder",
+          "symbol": "BTCUSDT",
+          "side": "SELL",
+          "kind": "entry",
+          "price": {"type": "series", "name": "close"},
+          "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.015"}
+        },
+        {
+          "type": "notify",
+          "channel": "alerts",
+          "message": "RSI short signal",
+          "severity": "warn",
+          "fields": {"rsi": {"type": "series", "name": "rsi14"}}
+        }
+      ],
+      "quota": {"max": 50, "windowMs": 86400000}
+    }
+  ]
+}

--- a/fixtures/strategies/zscore.json
+++ b/fixtures/strategies/zscore.json
@@ -1,0 +1,40 @@
+{
+  "id": "strategy_zscore",
+  "version": 1,
+  "interval": "H1",
+  "defaultSymbol": "BTCUSDT",
+  "inputs": [
+    {"symbol": "BTCUSDT", "csvPath": "fixtures/ohlcv/BTCUSDT_1h_sample.csv"}
+  ],
+  "series": [
+    {"name": "zscore_20", "type": "ZSCORE", "period": 20, "symbol": "BTCUSDT"}
+  ],
+  "rules": [
+    {
+      "id": "zscore_long",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "zscore_20"},
+        "dir": "BELOW",
+        "right": {"type": "const", "value": -2.0}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "BUY", "kind": "mean_revert", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.012"}}
+      ]
+    },
+    {
+      "id": "zscore_short",
+      "event": {"type": "candle", "symbol": "BTCUSDT"},
+      "guard": {
+        "type": "crosses",
+        "left": {"type": "series", "name": "zscore_20"},
+        "dir": "ABOVE",
+        "right": {"type": "const", "value": 2.0}
+      },
+      "actions": [
+        {"type": "emitOrder", "symbol": "BTCUSDT", "side": "SELL", "kind": "mean_revert", "price": {"type": "series", "name": "close"}, "metaStrings": {"risk.mode": "fixed_pct", "risk.pct": "0.012"}}
+      ]
+    }
+  ]
+}

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/AutomationRuntimeImpl.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/AutomationRuntimeImpl.kt
@@ -6,7 +6,6 @@ import com.kevin.cryptotrader.contracts.Intent
 import com.kevin.cryptotrader.contracts.LoadedProgram
 import com.kevin.cryptotrader.contracts.RuntimeEnv
 import com.kevin.cryptotrader.runtime.vm.InputLoader
-import com.kevin.cryptotrader.runtime.vm.InputBar
 import com.kevin.cryptotrader.runtime.vm.Interpreter
 import com.kevin.cryptotrader.runtime.vm.ProgramJson
 import kotlinx.coroutines.flow.Flow
@@ -14,7 +13,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
 
 class AutomationRuntimeImpl : AutomationRuntime {
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json { ignoreUnknownKeys = true; classDiscriminator = "type" }
   @Volatile private var loaded: LoadedProgramImpl? = null
 
   override fun load(def: AutomationDef): LoadedProgram {
@@ -31,11 +30,7 @@ class AutomationRuntimeImpl : AutomationRuntime {
 
   private class LoadedProgramImpl(private val program: ProgramJson) : LoadedProgram {
     fun run(env: RuntimeEnv): Flow<Intent> {
-      val inputs: List<InputBar> = when {
-        program.inputsInline != null -> program.inputsInline.map { InputBar(it.ts, it.open, it.high, it.low, it.close, it.volume) }
-        program.inputsCsvPath != null -> InputLoader.fromCsv(program.inputsCsvPath)
-        else -> emptyList()
-      }
+      val inputs = InputLoader.loadInputs(program)
       val interp = Interpreter(program)
       return interp.run(inputs)
     }

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionCoordinator.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/execution/ExecutionCoordinator.kt
@@ -34,11 +34,11 @@ class ExecutionCoordinator(
         ledger.append(LedgerEvent.NetPlanReady(now, netPlan))
 
         val account = broker.account()
-        val orders = riskSizer.size(netPlan, account)
-        if (orders.isEmpty()) return
-        ledger.append(LedgerEvent.OrdersSized(now, orders))
+        val riskResult = riskSizer.size(netPlan, account)
+        if (riskResult.orders.isEmpty()) return
+        ledger.append(LedgerEvent.OrdersSized(now, riskResult.orders))
 
-        for (order in orders) {
+        for (order in riskResult.orders) {
             val brokerId = broker.place(order)
             ledger.append(LedgerEvent.OrderRouted(clock.millis(), order, brokerId))
         }

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/vm/Bytecode.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/vm/Bytecode.kt
@@ -10,10 +10,21 @@ data class ProgramJson(
   val id: String,
   val version: Int,
   val interval: Interval = Interval.H1,
+  val defaultSymbol: String? = null,
+  val inputs: List<InputSourceJson> = emptyList(),
   val inputsCsvPath: String? = null,
   val inputsInline: List<InputBarJson>? = null,
   val series: List<SeriesDefJson> = emptyList(),
   val rules: List<RuleJson> = emptyList(),
+  val fillEvents: List<FillEventJson> = emptyList(),
+  val pnlEvents: List<PnLEventJson> = emptyList(),
+)
+
+@Serializable
+data class InputSourceJson(
+  val symbol: String,
+  val csvPath: String? = null,
+  val inline: List<InputBarJson>? = null,
 )
 
 @Serializable
@@ -25,10 +36,30 @@ data class SeriesDefJson(
   val type: SeriesType,
   val period: Int? = null,
   val source: SourceKey = SourceKey.CLOSE,
+  val symbol: String? = null,
+  val params: Map<String, Double> = emptyMap(),
 )
 
 @Serializable
-enum class SeriesType { EMA }
+enum class SeriesType {
+  EMA,
+  SMA,
+  WMA,
+  RSI,
+  MACD,
+  MACD_SIGNAL,
+  MACD_HIST,
+  BOLLINGER_MIDDLE,
+  BOLLINGER_UPPER,
+  BOLLINGER_LOWER,
+  BOLLINGER_STDDEV,
+  DONCHIAN_UPPER,
+  DONCHIAN_LOWER,
+  DONCHIAN_MIDDLE,
+  ATR,
+  ZSCORE,
+  ROC,
+}
 
 @Serializable
 enum class SourceKey { OPEN, HIGH, LOW, CLOSE, VOLUME }
@@ -36,12 +67,40 @@ enum class SourceKey { OPEN, HIGH, LOW, CLOSE, VOLUME }
 @Serializable
 data class RuleJson(
   val id: String,
+  val event: EventJson = EventJson.Candle(),
   val oncePerBar: Boolean = true,
-  val guard: GuardJson,
-  val action: ActionJson,
+  val guard: GuardJson? = null,
+  val actions: List<ActionJson> = emptyList(),
   val quota: QuotaJson? = null,
   val delayMs: Long? = null,
 )
+
+@Serializable
+sealed class EventJson {
+  @Serializable
+  @SerialName("candle")
+  data class Candle(val symbol: String? = null) : EventJson()
+
+  @Serializable
+  @SerialName("schedule")
+  data class Schedule(
+    val everyMs: Long? = null,
+    val at: List<Long> = emptyList(),
+    val offsetMs: Long = 0L,
+  ) : EventJson()
+
+  @Serializable
+  @SerialName("fill")
+  data class Fill(val symbol: String? = null, val side: Side? = null) : EventJson()
+
+  @Serializable
+  @SerialName("pnl")
+  data class PnL(
+    val symbol: String? = null,
+    val realizedThreshold: Double? = null,
+    val unrealizedThreshold: Double? = null,
+  ) : EventJson()
+}
 
 @Serializable
 sealed class GuardJson {
@@ -52,6 +111,18 @@ sealed class GuardJson {
   @Serializable
   @SerialName("crosses")
   data class Crosses(val left: Operand, val dir: CrossDir, val right: Operand) : GuardJson()
+
+  @Serializable
+  @SerialName("always")
+  object Always : GuardJson()
+
+  @Serializable
+  @SerialName("and")
+  data class And(val guards: List<GuardJson>) : GuardJson()
+
+  @Serializable
+  @SerialName("or")
+  data class Or(val guards: List<GuardJson>) : GuardJson()
 }
 
 @Serializable
@@ -69,19 +140,124 @@ sealed class Operand {
   @Serializable
   @SerialName("const")
   data class Const(val value: Double) : Operand()
+
+  @Serializable
+  @SerialName("state")
+  data class State(val key: String, val default: Double? = null) : Operand()
+
+  @Serializable
+  @SerialName("math")
+  data class Math(val op: MathOp, val left: Operand, val right: Operand) : Operand()
+
+  @Serializable
+  @SerialName("abs")
+  data class Abs(val operand: Operand) : Operand()
 }
 
 @Serializable
-data class ActionJson(
-  val type: ActionType,
-  val symbol: String,
-  val side: Side,
-  val kind: String = "signal",
-)
+sealed class ActionJson {
+  @Serializable
+  @SerialName("emitOrder")
+  data class EmitOrder(
+    val symbol: String,
+    val side: Side,
+    val kind: String = "signal",
+    val qty: Operand? = null,
+    val notionalUsd: Operand? = null,
+    val price: Operand? = null,
+    val meta: Map<String, Operand> = emptyMap(),
+    val metaStrings: Map<String, String> = emptyMap(),
+  ) : ActionJson()
+
+  @Serializable
+  @SerialName("emitSpread")
+  data class EmitSpread(
+    val symbol: String,
+    val side: Side,
+    val offsetPct: Double,
+    val widthPct: Double,
+    val qty: Operand? = null,
+    val notionalUsd: Operand? = null,
+    val kind: String = "spread",
+    val metaStrings: Map<String, String> = emptyMap(),
+  ) : ActionJson()
+
+  @Serializable
+  @SerialName("setState")
+  data class SetState(val key: String, val value: Operand) : ActionJson()
+
+  @Serializable
+  @SerialName("incState")
+  data class IncState(val key: String, val delta: Operand) : ActionJson()
+
+  @Serializable
+  @SerialName("clearState")
+  data class ClearState(val key: String) : ActionJson()
+
+  @Serializable
+  @SerialName("setStopAtr")
+  data class SetStopAtr(
+    val symbol: String,
+    val side: Side,
+    val atrSeries: String,
+    val multiplier: Double,
+    val kind: String = "stop",
+  ) : ActionJson()
+
+  @Serializable
+  @SerialName("trailStop")
+  data class TrailStop(
+    val symbol: String,
+    val side: Side,
+    val trailPct: Double,
+    val kind: String = "stop",
+  ) : ActionJson()
+
+  @Serializable
+  @SerialName("log")
+  data class Log(
+    val message: String,
+    val level: LogLevel = LogLevel.INFO,
+    val fields: Map<String, Operand> = emptyMap(),
+  ) : ActionJson()
+
+  @Serializable
+  @SerialName("notify")
+  data class Notify(
+    val channel: String,
+    val message: String,
+    val severity: String = "info",
+    val fields: Map<String, Operand> = emptyMap(),
+  ) : ActionJson()
+
+  @Serializable
+  @SerialName("abort")
+  data class Abort(val reason: String = "") : ActionJson()
+}
 
 @Serializable
-enum class ActionType { EMIT }
+enum class LogLevel { DEBUG, INFO, WARN, ERROR }
+
+@Serializable
+enum class MathOp { ADD, SUB, MUL, DIV, MIN, MAX }
 
 @Serializable
 data class QuotaJson(val max: Int, val windowMs: Long)
+
+@Serializable
+data class FillEventJson(
+  val ts: Long,
+  val symbol: String,
+  val side: Side,
+  val price: Double,
+  val qty: Double,
+)
+
+@Serializable
+data class PnLEventJson(
+  val ts: Long,
+  val symbol: String,
+  val realized: Double = 0.0,
+  val unrealized: Double = 0.0,
+)
 

--- a/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/vm/Interpreter.kt
+++ b/runtime/src/main/kotlin/com/kevin/cryptotrader/runtime/vm/Interpreter.kt
@@ -1,122 +1,682 @@
 package com.kevin.cryptotrader.runtime.vm
 
 import com.kevin.cryptotrader.contracts.Intent
-import com.kevin.cryptotrader.contracts.Side
 import com.kevin.cryptotrader.contracts.Interval
+import com.kevin.cryptotrader.contracts.Side
+import com.kevin.cryptotrader.core.indicators.AtrIndicator
+import com.kevin.cryptotrader.core.indicators.Bollinger
+import com.kevin.cryptotrader.core.indicators.BollingerBands
+import com.kevin.cryptotrader.core.indicators.DonchianChannel
 import com.kevin.cryptotrader.core.indicators.EmaIndicator
+import com.kevin.cryptotrader.core.indicators.Donchian
+import com.kevin.cryptotrader.core.indicators.MacdIndicator
+import com.kevin.cryptotrader.core.indicators.RocIndicator
+import com.kevin.cryptotrader.core.indicators.RsiIndicator
+import com.kevin.cryptotrader.core.indicators.SmaIndicator
+import com.kevin.cryptotrader.core.indicators.WmaIndicator
+import com.kevin.cryptotrader.core.indicators.ZScore
+import com.kevin.cryptotrader.core.indicators.Macd
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.io.File
+import java.util.TreeSet
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
 
-data class InputBar(val ts: Long, val open: Double, val high: Double, val low: Double, val close: Double, val volume: Double)
+data class InputBar(
+  val ts: Long,
+  val open: Double,
+  val high: Double,
+  val low: Double,
+  val close: Double,
+  val volume: Double,
+)
+
+data class FillEvent(val ts: Long, val symbol: String, val side: Side, val price: Double, val qty: Double)
+
+data class PnLEvent(val ts: Long, val symbol: String, val realized: Double, val unrealized: Double)
 
 /** Build and run an interpreted program defined by ProgramJson */
 class Interpreter(private val program: ProgramJson) {
+  private val intentCounter = AtomicLong(0L)
 
-  fun run(input: List<InputBar>): Flow<Intent> = flow {
-    val seriesEngines = SeriesEngines(program.series)
-    val ctx = RuntimeCtx(program.interval)
+  fun run(input: List<InputBar>): Flow<Intent> {
+    val defaultSymbol = program.defaultSymbol ?: "symbol"
+    return run(mapOf(defaultSymbol to input))
+  }
 
-    input.forEach { bar ->
-      seriesEngines.update(bar)
+  fun run(inputs: Map<String, List<InputBar>>): Flow<Intent> = flow {
+    val symbolSet = if (inputs.isEmpty()) {
+      val sym = program.defaultSymbol ?: determineDefaultSymbol(emptySet())
+      setOf(sym)
+    } else {
+      inputs.keys
+    }
+    val defaultSymbol = program.defaultSymbol ?: determineDefaultSymbol(symbolSet)
+
+    val seriesEngines = SeriesEngines(program.series, defaultSymbol)
+    val ctx = RuntimeCtx(program.interval, defaultSymbol)
+    val state = HashMap<String, Double>()
+
+    val barsBySymbolAndTs = inputs.mapValues { (_, bars) -> bars.associateBy { it.ts } }
+    val allTimestamps = TreeSet<Long>()
+    barsBySymbolAndTs.values.forEach { map -> allTimestamps.addAll(map.keys) }
+
+    val fillByTs = program.fillEvents.groupBy { it.ts }.mapValues { entry ->
+      entry.value.map { FillEvent(it.ts, it.symbol, it.side, it.price, it.qty) }
+    }
+    val pnlByTs = program.pnlEvents.groupBy { it.ts }.mapValues { entry ->
+      entry.value.map { PnLEvent(it.ts, it.symbol, it.realized, it.unrealized) }
+    }
+    allTimestamps.addAll(fillByTs.keys)
+    allTimestamps.addAll(pnlByTs.keys)
+
+    for (ts in allTimestamps) {
+      val barsAtTs = symbolSet.associateWith { symbol -> barsBySymbolAndTs[symbol]?.get(ts) }
+      seriesEngines.update(ts, barsAtTs)
+
+      val frame = EventFrame(
+        ts = ts,
+        bars = barsAtTs,
+        fills = fillByTs[ts].orEmpty(),
+        pnls = pnlByTs[ts].orEmpty(),
+      )
+
+      ctx.updateEventState(frame, state)
+
       for (rule in program.rules) {
-        if (rule.oncePerBar && !ctx.allowOncePerBar(rule.id, bar.ts)) continue
+        if (!ctx.shouldTrigger(rule, frame)) continue
 
-        val guardPass = when (val g = rule.guard) {
-          is GuardJson.Threshold -> evalThreshold(g, seriesEngines)
-          is GuardJson.Crosses -> ctx.evalCrosses(g, seriesEngines)
+        val guardPass = rule.guard?.let { evalGuard(it, seriesEngines, state, ctx) } ?: true
+        val ready = ctx.updateTimerAndCheck(rule.id, frame.ts, rule.delayMs, guardPass)
+        if (!guardPass || !ready) continue
+        if (!ctx.quotaPrecheck(rule.id, frame.ts, rule.quota)) continue
+
+        var aborted = false
+        val actions = rule.actions
+        if (actions.isEmpty()) continue
+        actions.forEachIndexed { index, action ->
+          if (aborted) return@forEachIndexed
+          val results = executeAction(action, rule.id, index, frame, seriesEngines, state)
+          results.forEach { emit(it) }
+          if (action is ActionJson.Abort) {
+            aborted = true
+          }
         }
-
-        val ready = ctx.updateTimerAndCheck(rule.id, bar.ts, rule.delayMs, guardPass)
-        val allowed = ready && ctx.quotaPrecheck(rule.id, bar.ts, rule.quota)
-        if (allowed) {
-          val out = toIntent(rule.action, rule.id)
-          emit(out)
-          ctx.recordEmit(rule.id, bar.ts, rule.quota)
+        if (!aborted) {
+          ctx.recordEmit(rule.id, frame.ts, rule.quota)
         }
       }
     }
   }
 
-  private fun toIntent(action: ActionJson, sourceId: String): Intent {
-    return Intent(
-      id = "i-" + sourceId + "-" + System.identityHashCode(this),
-      sourceId = sourceId,
-      kind = action.kind,
-      symbol = action.symbol,
-      side = action.side,
-      notionalUsd = null,
-      qty = null,
-      priceHint = null,
-      meta = emptyMap(),
-    )
+  private fun determineDefaultSymbol(candidates: Set<String>): String {
+    if (program.defaultSymbol != null) return program.defaultSymbol
+    program.rules.firstOrNull { it.event is EventJson.Candle }?.let { rule ->
+      val candle = rule.event as EventJson.Candle
+      if (!candle.symbol.isNullOrBlank()) return candle.symbol
+    }
+    return candidates.firstOrNull() ?: "UNKNOWN"
   }
 
-  private fun evalThreshold(t: GuardJson.Threshold, engines: SeriesEngines): Boolean {
-    val l = engines.resolve(t.left) ?: return false
-    val r = engines.resolve(t.right) ?: return false
-    return when (t.op) {
-      Op.GT -> l > r
-      Op.GTE -> l >= r
-      Op.LT -> l < r
-      Op.LTE -> l <= r
-      Op.EQ -> l == r
+  private fun evalGuard(
+    guard: GuardJson,
+    engines: SeriesEngines,
+    state: MutableMap<String, Double>,
+    ctx: RuntimeCtx,
+  ): Boolean {
+    return when (guard) {
+      is GuardJson.Threshold -> {
+        val l = evalOperand(guard.left, engines, state)
+        val r = evalOperand(guard.right, engines, state)
+        if (l == null || r == null) return false
+        when (guard.op) {
+          Op.GT -> l > r
+          Op.GTE -> l >= r
+          Op.LT -> l < r
+          Op.LTE -> l <= r
+          Op.EQ -> l == r
+        }
+      }
+      is GuardJson.Crosses -> {
+        val l = evalOperand(guard.left, engines, state)
+        val r = evalOperand(guard.right, engines, state)
+        ctx.evalCrosses("${guard.left}-${guard.right}", guard.dir, l, r)
+      }
+      GuardJson.Always -> true
+      is GuardJson.And -> guard.guards.all { evalGuard(it, engines, state, ctx) }
+      is GuardJson.Or -> guard.guards.any { evalGuard(it, engines, state, ctx) }
     }
+  }
+
+  private fun evalOperand(op: Operand, engines: SeriesEngines, state: MutableMap<String, Double>): Double? {
+    return when (op) {
+      is Operand.Const -> op.value
+      is Operand.Series -> engines.value(op.name)
+      is Operand.State -> state[op.key] ?: op.default
+      is Operand.Math -> {
+        val l = evalOperand(op.left, engines, state) ?: return null
+        val r = evalOperand(op.right, engines, state) ?: return null
+        when (op.op) {
+          MathOp.ADD -> l + r
+          MathOp.SUB -> l - r
+          MathOp.MUL -> l * r
+          MathOp.DIV -> if (abs(r) <= 1e-12) null else l / r
+          MathOp.MIN -> min(l, r)
+          MathOp.MAX -> max(l, r)
+        }
+      }
+      is Operand.Abs -> evalOperand(op.operand, engines, state)?.let { abs(it) }
+    }
+  }
+
+  private fun executeAction(
+    action: ActionJson,
+    ruleId: String,
+    actionIndex: Int,
+    frame: EventFrame,
+    engines: SeriesEngines,
+    state: MutableMap<String, Double>,
+  ): List<Intent> {
+    return when (action) {
+      is ActionJson.EmitOrder -> {
+        val qty = action.qty?.let { evalOperand(it, engines, state) }
+        val notional = action.notionalUsd?.let { evalOperand(it, engines, state) }
+        val price = action.price?.let { evalOperand(it, engines, state) }
+        val meta = HashMap<String, String>()
+        action.meta.forEach { (k, v) ->
+          evalOperand(v, engines, state)?.let { meta[k] = it.toString() }
+        }
+        action.metaStrings.forEach { (k, v) -> meta[k] = v }
+
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = action.kind,
+            symbol = action.symbol,
+            side = action.side,
+            notionalUsd = notional,
+            qty = qty,
+            priceHint = price,
+            meta = meta,
+          ),
+        )
+      }
+      is ActionJson.EmitSpread -> {
+        val qty = action.qty?.let { evalOperand(it, engines, state) }
+        val notional = action.notionalUsd?.let { evalOperand(it, engines, state) }
+        val meta = HashMap<String, String>()
+        meta["spread.offset_pct"] = action.offsetPct.toString()
+        meta["spread.width_pct"] = action.widthPct.toString()
+        action.metaStrings.forEach { (k, v) -> meta[k] = v }
+
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = action.kind,
+            symbol = action.symbol,
+            side = action.side,
+            notionalUsd = notional,
+            qty = qty,
+            priceHint = null,
+            meta = meta,
+          ),
+        )
+      }
+      is ActionJson.SetState -> {
+        evalOperand(action.value, engines, state)?.let { state[action.key] = it }
+        emptyList()
+      }
+      is ActionJson.IncState -> {
+        val delta = evalOperand(action.delta, engines, state)
+        if (delta != null) {
+          val next = state.getOrDefault(action.key, 0.0) + delta
+          state[action.key] = next
+        }
+        emptyList()
+      }
+      is ActionJson.ClearState -> {
+        state.remove(action.key)
+        emptyList()
+      }
+      is ActionJson.SetStopAtr -> {
+        val atr = engines.value(action.atrSeries)
+        val meta = mapOf(
+          "stop.kind" to "ATR",
+          "stop.atr_mult" to action.multiplier.toString(),
+          "risk.atr" to (atr ?: 0.0).toString(),
+        )
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = action.kind,
+            symbol = action.symbol,
+            side = action.side,
+            meta = meta,
+          ),
+        )
+      }
+      is ActionJson.TrailStop -> {
+        val meta = mapOf(
+          "stop.kind" to "TRAILING",
+          "stop.trailing_pct" to action.trailPct.toString(),
+        )
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = action.kind,
+            symbol = action.symbol,
+            side = action.side,
+            meta = meta,
+          ),
+        )
+      }
+      is ActionJson.Log -> {
+        val meta = HashMap<String, String>()
+        meta["log.message"] = action.message
+        meta["log.level"] = action.level.name
+        action.fields.forEach { (k, v) ->
+          evalOperand(v, engines, state)?.let { meta["log.$k"] = it.toString() }
+        }
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = "log",
+            symbol = engines.defaultSymbol,
+            side = Side.BUY,
+            meta = meta,
+          ),
+        )
+      }
+      is ActionJson.Notify -> {
+        val meta = HashMap<String, String>()
+        meta["notify.channel"] = action.channel
+        meta["notify.message"] = action.message
+        meta["notify.severity"] = action.severity
+        action.fields.forEach { (k, v) ->
+          evalOperand(v, engines, state)?.let { meta["notify.$k"] = it.toString() }
+        }
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = "notify",
+            symbol = engines.defaultSymbol,
+            side = Side.BUY,
+            meta = meta,
+          ),
+        )
+      }
+      is ActionJson.Abort -> {
+        listOf(
+          Intent(
+            id = buildIntentId(ruleId, actionIndex),
+            sourceId = ruleId,
+            kind = "abort",
+            symbol = engines.defaultSymbol,
+            side = Side.BUY,
+            meta = mapOf("abort.reason" to action.reason),
+          ),
+        )
+      }
+    }
+  }
+
+  private fun buildIntentId(ruleId: String, actionIndex: Int): String {
+    val counter = intentCounter.incrementAndGet()
+    return "i-$ruleId-$actionIndex-$counter"
   }
 }
 
-private class SeriesEngines(seriesDefs: List<SeriesDefJson>) {
-  private data class Engine(val name: String, val type: SeriesType, val ema: EmaIndicator?, val source: SourceKey)
-  private val engines: List<Engine>
-  private var last: InputBar? = null
+private data class EventFrame(
+  val ts: Long,
+  val bars: Map<String, InputBar?>,
+  val fills: List<FillEvent>,
+  val pnls: List<PnLEvent>,
+)
+
+private class SeriesEngines(
+  seriesDefs: List<SeriesDefJson>,
+  val defaultSymbol: String,
+) {
+  private data class SingleEngine(
+    val name: String,
+    val symbol: String,
+    val source: SourceKey,
+    val type: SeriesType,
+    val ema: EmaIndicator? = null,
+    val sma: SmaIndicator? = null,
+    val wma: WmaIndicator? = null,
+    val rsi: RsiIndicator? = null,
+    val zscore: ZScore? = null,
+    val roc: RocIndicator? = null,
+  )
+
+  private data class MacdBundle(
+    val symbol: String,
+    val source: SourceKey,
+    val indicator: MacdIndicator,
+    var lastTs: Long = Long.MIN_VALUE,
+    var last: Macd? = null,
+  )
+
+  private data class BollBundle(
+    val symbol: String,
+    val source: SourceKey,
+    val indicator: BollingerBands,
+    var lastTs: Long = Long.MIN_VALUE,
+    var last: Bollinger? = null,
+  )
+
+  private data class DonchianBundle(
+    val symbol: String,
+    val indicator: DonchianChannel,
+    var lastTs: Long = Long.MIN_VALUE,
+    var last: Donchian? = null,
+  )
+
+  private data class AtrBundle(
+    val symbol: String,
+    val indicator: AtrIndicator,
+    var lastTs: Long = Long.MIN_VALUE,
+    var last: Double? = null,
+  )
+
+  private data class MacdOutput(val name: String, val type: SeriesType, val key: String)
+  private data class BollOutput(val name: String, val type: SeriesType, val key: String)
+  private data class DonchianOutput(val name: String, val type: SeriesType, val key: String)
+  private data class AtrOutput(val name: String, val key: String)
+
+  private val singleEngines = mutableListOf<SingleEngine>()
+  private val macdOutputs = mutableMapOf<String, MutableList<MacdOutput>>()
+  private val macdBundles = mutableMapOf<String, MacdBundle>()
+  private val bollOutputs = mutableMapOf<String, MutableList<BollOutput>>()
+  private val bollBundles = mutableMapOf<String, BollBundle>()
+  private val donchianOutputs = mutableMapOf<String, MutableList<DonchianOutput>>()
+  private val donchianBundles = mutableMapOf<String, DonchianBundle>()
+  private val atrOutputs = mutableMapOf<String, MutableList<AtrOutput>>()
+  private val atrBundles = mutableMapOf<String, AtrBundle>()
+
   private val currentValues = HashMap<String, Double?>()
+  private val lastBars = HashMap<String, InputBar>()
 
   init {
-    engines = seriesDefs.map { def ->
+    seriesDefs.forEach { def ->
+      val symbol = def.symbol ?: defaultSymbol
       when (def.type) {
-        SeriesType.EMA -> Engine(def.name, def.type, EmaIndicator(def.period ?: error("EMA requires period")), def.source)
+        SeriesType.EMA -> singleEngines.add(
+          SingleEngine(
+            name = def.name,
+            symbol = symbol,
+            source = def.source,
+            type = def.type,
+            ema = EmaIndicator(def.period ?: error("EMA requires period")),
+          ),
+        )
+        SeriesType.SMA -> singleEngines.add(
+          SingleEngine(
+            name = def.name,
+            symbol = symbol,
+            source = def.source,
+            type = def.type,
+            sma = SmaIndicator(def.period ?: error("SMA requires period")),
+          ),
+        )
+        SeriesType.WMA -> singleEngines.add(
+          SingleEngine(
+            name = def.name,
+            symbol = symbol,
+            source = def.source,
+            type = def.type,
+            wma = WmaIndicator(def.period ?: error("WMA requires period")),
+          ),
+        )
+        SeriesType.RSI -> singleEngines.add(
+          SingleEngine(
+            name = def.name,
+            symbol = symbol,
+            source = def.source,
+            type = def.type,
+            rsi = RsiIndicator(def.period ?: error("RSI requires period")),
+          ),
+        )
+        SeriesType.ZSCORE -> singleEngines.add(
+          SingleEngine(
+            name = def.name,
+            symbol = symbol,
+            source = def.source,
+            type = def.type,
+            zscore = ZScore(def.period ?: error("ZScore requires period")),
+          ),
+        )
+        SeriesType.ROC -> singleEngines.add(
+          SingleEngine(
+            name = def.name,
+            symbol = symbol,
+            source = def.source,
+            type = def.type,
+            roc = RocIndicator(def.period ?: error("ROC requires period")),
+          ),
+        )
+        SeriesType.MACD, SeriesType.MACD_SIGNAL, SeriesType.MACD_HIST -> {
+          val fast = def.params["fast"]?.toInt() ?: 12
+          val slow = def.params["slow"]?.toInt() ?: 26
+          val signalPeriod = def.params["signal"]?.toInt() ?: 9
+          val key = "${symbol}:${def.source}:$fast:$slow:$signalPeriod"
+          macdBundles.getOrPut(key) {
+            MacdBundle(symbol, def.source, MacdIndicator(fast, slow, signalPeriod))
+          }
+          macdOutputs.getOrPut(key) { mutableListOf() }
+            .add(MacdOutput(def.name, def.type, key))
+        }
+        SeriesType.BOLLINGER_MIDDLE,
+        SeriesType.BOLLINGER_UPPER,
+        SeriesType.BOLLINGER_LOWER,
+        SeriesType.BOLLINGER_STDDEV -> {
+          val k = def.params["k"] ?: 2.0
+          val period = def.period ?: error("Bollinger requires period")
+          val key = "${symbol}:${def.source}:$period:$k"
+          bollBundles.getOrPut(key) { BollBundle(symbol, def.source, BollingerBands(period, k)) }
+          bollOutputs.getOrPut(key) { mutableListOf() }
+            .add(BollOutput(def.name, def.type, key))
+        }
+        SeriesType.DONCHIAN_UPPER,
+        SeriesType.DONCHIAN_LOWER,
+        SeriesType.DONCHIAN_MIDDLE -> {
+          val period = def.period ?: error("Donchian requires period")
+          val key = "${symbol}:$period"
+          donchianBundles.getOrPut(key) { DonchianBundle(symbol, DonchianChannel(period)) }
+          donchianOutputs.getOrPut(key) { mutableListOf() }
+            .add(DonchianOutput(def.name, def.type, key))
+        }
+        SeriesType.ATR -> {
+          val period = def.period ?: 14
+          val key = "${symbol}:$period"
+          atrBundles.getOrPut(key) { AtrBundle(symbol, AtrIndicator(period)) }
+          atrOutputs.getOrPut(key) { mutableListOf() }
+            .add(AtrOutput(def.name, key))
+        }
       }
     }
   }
 
-  fun update(bar: InputBar) {
-    last = bar
-    engines.forEach { e ->
-      val src = when (e.source) {
+  fun update(ts: Long, bars: Map<String, InputBar?>) {
+    bars.forEach { (symbol, bar) ->
+      if (bar != null) {
+        lastBars[symbol] = bar
+      }
+    }
+
+    singleEngines.forEach { engine ->
+      val bar = lastBars[engine.symbol] ?: return@forEach
+      val src = when (engine.source) {
         SourceKey.OPEN -> bar.open
         SourceKey.HIGH -> bar.high
         SourceKey.LOW -> bar.low
         SourceKey.CLOSE -> bar.close
         SourceKey.VOLUME -> bar.volume
       }
-      val v = when (e.type) {
-        SeriesType.EMA -> e.ema!!.update(src)
+      val value = when (engine.type) {
+        SeriesType.EMA -> engine.ema!!.update(src)
+        SeriesType.SMA -> engine.sma!!.update(src)
+        SeriesType.WMA -> engine.wma!!.update(src)
+        SeriesType.RSI -> engine.rsi!!.update(src)
+        SeriesType.ZSCORE -> engine.zscore!!.update(src)
+        SeriesType.ROC -> engine.roc!!.update(src)
+        else -> null
       }
-      currentValues[e.name] = v
+      currentValues[engine.name] = value
     }
-    // Expose raw sources as well
-    currentValues["open"] = bar.open
-    currentValues["high"] = bar.high
-    currentValues["low"] = bar.low
-    currentValues["close"] = bar.close
-    currentValues["volume"] = bar.volume
+
+    macdBundles.forEach { (key, bundle) ->
+      val bar = lastBars[bundle.symbol]
+      if (bar != null) {
+        val src = when (bundle.source) {
+          SourceKey.OPEN -> bar.open
+          SourceKey.HIGH -> bar.high
+          SourceKey.LOW -> bar.low
+          SourceKey.CLOSE -> bar.close
+          SourceKey.VOLUME -> bar.volume
+        }
+        if (bundle.lastTs != ts) {
+          bundle.last = bundle.indicator.update(src)
+          bundle.lastTs = ts
+        }
+        macdOutputs[key]?.forEach { out ->
+          val macd = bundle.last
+          val value = when (out.type) {
+            SeriesType.MACD -> macd?.macd
+            SeriesType.MACD_SIGNAL -> macd?.signal
+            SeriesType.MACD_HIST -> macd?.hist
+            else -> null
+          }
+          currentValues[out.name] = value
+        }
+      }
+    }
+
+    bollBundles.forEach { (key, bundle) ->
+      val bar = lastBars[bundle.symbol]
+      if (bar != null) {
+        val src = when (bundle.source) {
+          SourceKey.OPEN -> bar.open
+          SourceKey.HIGH -> bar.high
+          SourceKey.LOW -> bar.low
+          SourceKey.CLOSE -> bar.close
+          SourceKey.VOLUME -> bar.volume
+        }
+        if (bundle.lastTs != ts) {
+          bundle.last = bundle.indicator.update(src)
+          bundle.lastTs = ts
+        }
+        bollOutputs[key]?.forEach { out ->
+          val bb = bundle.last
+          val value = when (out.type) {
+            SeriesType.BOLLINGER_MIDDLE -> bb?.middle
+            SeriesType.BOLLINGER_UPPER -> bb?.upper
+            SeriesType.BOLLINGER_LOWER -> bb?.lower
+            SeriesType.BOLLINGER_STDDEV -> bb?.stddev
+            else -> null
+          }
+          currentValues[out.name] = value
+        }
+      }
+    }
+
+    donchianBundles.forEach { (key, bundle) ->
+      val bar = lastBars[bundle.symbol]
+      if (bar != null && bundle.lastTs != ts) {
+        bundle.last = bundle.indicator.update(bar.high, bar.low)
+        bundle.lastTs = ts
+      }
+      donchianOutputs[key]?.forEach { out ->
+        val dc = bundle.last
+        val value = when (out.type) {
+          SeriesType.DONCHIAN_UPPER -> dc?.upper
+          SeriesType.DONCHIAN_LOWER -> dc?.lower
+          SeriesType.DONCHIAN_MIDDLE -> dc?.middle
+          else -> null
+        }
+        currentValues[out.name] = value
+      }
+    }
+
+    atrBundles.forEach { (key, bundle) ->
+      val bar = lastBars[bundle.symbol]
+      if (bar != null && bundle.lastTs != ts) {
+        bundle.last = bundle.indicator.update(bar.high, bar.low, bar.close)
+        bundle.lastTs = ts
+      }
+      atrOutputs[key]?.forEach { out ->
+        currentValues[out.name] = bundle.last
+      }
+    }
+
+    lastBars.forEach { (symbol, bar) ->
+      currentValues["open:$symbol"] = bar.open
+      currentValues["high:$symbol"] = bar.high
+      currentValues["low:$symbol"] = bar.low
+      currentValues["close:$symbol"] = bar.close
+      currentValues["volume:$symbol"] = bar.volume
+      if (symbol == defaultSymbol) {
+        currentValues["open"] = bar.open
+        currentValues["high"] = bar.high
+        currentValues["low"] = bar.low
+        currentValues["close"] = bar.close
+        currentValues["volume"] = bar.volume
+      }
+    }
   }
 
   fun value(name: String): Double? = currentValues[name]
-
-  fun resolve(op: Operand): Double? = when (op) {
-    is Operand.Const -> op.value
-    is Operand.Series -> value(op.name)
-  }
 }
 
-private class RuntimeCtx(private val interval: Interval) {
+private class RuntimeCtx(
+  private val interval: Interval,
+  private val defaultSymbol: String,
+) {
   private val lastBarByRule = HashMap<String, Long>()
-  private val lastPairs = HashMap<String, Pair<Double?, Double?>>() // key -> (prevLeft, prevRight)
-  private val pendingAt = HashMap<String, Long?>() // ruleId -> dueTs
+  private val lastPairs = HashMap<String, Pair<Double?, Double?>>()
+  private val pendingAt = HashMap<String, Long?>()
   private val quota = HashMap<String, ArrayDeque<Long>>()
+  private val scheduleBase = HashMap<String, Long>()
+  private val scheduleDue = HashMap<String, Long>()
+  private val scheduleOnce = HashMap<String, MutableSet<Long>>()
 
-  fun allowOncePerBar(ruleId: String, ts: Long): Boolean {
+  fun shouldTrigger(rule: RuleJson, frame: EventFrame): Boolean {
+    return when (val event = rule.event) {
+      is EventJson.Candle -> {
+        val symbol = event.symbol ?: defaultSymbol
+        val bar = frame.bars[symbol] ?: return false
+        if (rule.oncePerBar && !allowOncePerBar(rule.id, bar.ts)) return false
+        true
+      }
+      is EventJson.Schedule -> allowSchedule(rule.id, frame.ts, event)
+      is EventJson.Fill -> frame.fills.any { fill ->
+        (event.symbol == null || event.symbol == fill.symbol) &&
+          (event.side == null || event.side == fill.side)
+      }
+      is EventJson.PnL -> frame.pnls.any { pnl ->
+        if (event.symbol != null && pnl.symbol != event.symbol) return@any false
+        val realizedOk = event.realizedThreshold?.let { threshold ->
+          if (threshold >= 0) pnl.realized >= threshold else pnl.realized <= threshold
+        } ?: true
+        val unrealizedOk = event.unrealizedThreshold?.let { threshold ->
+          if (threshold >= 0) pnl.unrealized >= threshold else pnl.unrealized <= threshold
+        } ?: true
+        realizedOk && unrealizedOk
+      }
+    }
+  }
+
+  private fun allowOncePerBar(ruleId: String, ts: Long): Boolean {
     val bar = barBucket(ts)
     val last = lastBarByRule[ruleId]
     return if (last == bar) {
@@ -127,16 +687,41 @@ private class RuntimeCtx(private val interval: Interval) {
     }
   }
 
-  fun evalCrosses(c: GuardJson.Crosses, engines: SeriesEngines): Boolean {
-    val l = engines.resolve(c.left) ?: return false
-    val r = engines.resolve(c.right) ?: return false
-    val key = "${c.left}-${c.right}-${c.dir}"
-    val (prevL, prevR) = lastPairs.getOrPut(key) { Pair(null, null) }
-    val crossed = when (c.dir) {
-      CrossDir.ABOVE -> (prevL != null && prevR != null && prevL <= prevR && l > r)
-      CrossDir.BELOW -> (prevL != null && prevR != null && prevL >= prevR && l < r)
+  private fun allowSchedule(ruleId: String, ts: Long, schedule: EventJson.Schedule): Boolean {
+    val atSet = if (schedule.at.isNotEmpty()) {
+      scheduleOnce.getOrPut(ruleId) { schedule.at.toMutableSet() }
+    } else null
+    if (atSet != null && atSet.remove(ts)) return true
+
+    val every = schedule.everyMs
+    if (every == null || every <= 0) {
+      return false
     }
-    lastPairs[key] = Pair(l, r)
+
+    val base = scheduleBase.getOrPut(ruleId) { ts + schedule.offsetMs }
+    val due = scheduleDue.getOrPut(ruleId) { base }
+    if (ts >= due) {
+      var next = due + every
+      if (next <= ts) {
+        val laps = max(1L, (ts - due) / every + 1)
+        next = due + laps * every
+      }
+      scheduleDue[ruleId] = next
+      return true
+    }
+    return false
+  }
+
+  fun evalCrosses(key: String, dir: CrossDir, left: Double?, right: Double?): Boolean {
+    if (left == null || right == null) return false
+    val pair = lastPairs.getOrPut(key) { Pair(null, null) }
+    val prevLeft = pair.first
+    val prevRight = pair.second
+    val crossed = when (dir) {
+      CrossDir.ABOVE -> prevLeft != null && prevRight != null && prevLeft <= prevRight && left > right
+      CrossDir.BELOW -> prevLeft != null && prevRight != null && prevLeft >= prevRight && left < right
+    }
+    lastPairs[key] = Pair(left, right)
     return crossed
   }
 
@@ -144,7 +729,7 @@ private class RuntimeCtx(private val interval: Interval) {
     val due = pendingAt[ruleId]
     if (guardPass) {
       if (delayMs == null || delayMs <= 0) return true
-      val newDue = (due ?: (ts + delayMs))
+      val newDue = due ?: (ts + delayMs)
       pendingAt[ruleId] = newDue
       if (ts >= newDue) {
         pendingAt.remove(ruleId)
@@ -174,6 +759,40 @@ private class RuntimeCtx(private val interval: Interval) {
     dq.addLast(ts)
   }
 
+  fun updateEventState(frame: EventFrame, state: MutableMap<String, Double>) {
+    frame.bars.forEach { (symbol, bar) ->
+      if (bar != null) {
+        state["bar.open.$symbol"] = bar.open
+        state["bar.high.$symbol"] = bar.high
+        state["bar.low.$symbol"] = bar.low
+        state["bar.close.$symbol"] = bar.close
+        state["bar.volume.$symbol"] = bar.volume
+        if (symbol == defaultSymbol) {
+          state["bar.open"] = bar.open
+          state["bar.high"] = bar.high
+          state["bar.low"] = bar.low
+          state["bar.close"] = bar.close
+          state["bar.volume"] = bar.volume
+        }
+      }
+    }
+
+    frame.fills.forEach { fill ->
+      state["event.fill.price.${fill.symbol}.${fill.side}"] = fill.price
+      state["event.fill.qty.${fill.symbol}.${fill.side}"] = fill.qty
+      state["event.fill.ts"] = fill.ts.toDouble()
+    }
+
+    frame.pnls.forEach { pnl ->
+      state["event.pnl.realized.${pnl.symbol}"] = pnl.realized
+      state["event.pnl.unrealized.${pnl.symbol}"] = pnl.unrealized
+      if (pnl.symbol == defaultSymbol) {
+        state["event.pnl.realized"] = pnl.realized
+        state["event.pnl.unrealized"] = pnl.unrealized
+      }
+    }
+  }
+
   private fun barBucket(ts: Long): Long {
     val ms = when (interval) {
       Interval.M1 -> 60_000L
@@ -194,8 +813,37 @@ object InputLoader {
     val lines = file.readLines().drop(1)
     return lines.map { ln ->
       val p = ln.split(',')
-      InputBar(p[0].toLong(), p[1].toDouble(), p[2].toDouble(), p[3].toDouble(), p[4].toDouble(), p[5].toDouble())
+      InputBar(
+        ts = p[0].toLong(),
+        open = p[1].toDouble(),
+        high = p[2].toDouble(),
+        low = p[3].toDouble(),
+        close = p[4].toDouble(),
+        volume = p[5].toDouble(),
+      )
     }
+  }
+
+  fun fromInline(bars: List<InputBarJson>): List<InputBar> {
+    return bars.map { InputBar(it.ts, it.open, it.high, it.low, it.close, it.volume) }
+  }
+
+  fun loadInputs(program: ProgramJson): Map<String, List<InputBar>> {
+    if (program.inputs.isNotEmpty()) {
+      return program.inputs.associate { src ->
+        val bars = when {
+          src.inline != null -> fromInline(src.inline)
+          src.csvPath != null -> fromCsv(src.csvPath)
+          else -> emptyList()
+        }
+        src.symbol to bars
+      }
+    }
+
+    val symbol = program.defaultSymbol ?: "symbol"
+    program.inputsInline?.let { inline -> return mapOf(symbol to fromInline(inline)) }
+    program.inputsCsvPath?.let { path -> return mapOf(symbol to fromCsv(path)) }
+    return emptyMap()
   }
 
   private fun resolvePath(path: String): File {

--- a/tools/src/test/kotlin/com/kevin/cryptotrader/tools/backtest/BacktesterTest.kt
+++ b/tools/src/test/kotlin/com/kevin/cryptotrader/tools/backtest/BacktesterTest.kt
@@ -13,24 +13,31 @@ class BacktesterTest {
         "id":"p1",
         "version":1,
         "interval":"H1",
-        "inputsCsvPath":"fixtures/ohlcv/BTCUSDT_1h_sample.csv",
+        "defaultSymbol":"BTCUSDT",
+        "inputs":[{"symbol":"BTCUSDT","csvPath":"fixtures/ohlcv/BTCUSDT_1h_sample.csv"}],
         "series":[
-          {"name":"ema12","type":"EMA","period":12,"source":"CLOSE"},
-          {"name":"ema26","type":"EMA","period":26,"source":"CLOSE"}
+          {"name":"ema12","type":"EMA","period":12,"source":"CLOSE","symbol":"BTCUSDT"},
+          {"name":"ema26","type":"EMA","period":26,"source":"CLOSE","symbol":"BTCUSDT"}
         ],
         "rules":[
           {
             "id":"long",
+            "event":{"type":"candle","symbol":"BTCUSDT"},
             "oncePerBar":true,
             "guard":{ "type":"crosses", "left":{"type":"series","name":"ema12"}, "dir":"ABOVE", "right":{"type":"series","name":"ema26"} },
-            "action":{ "type":"EMIT", "symbol":"BTCUSDT", "side":"BUY", "kind":"signal"},
+            "actions":[
+              { "type":"emitOrder", "symbol":"BTCUSDT", "side":"BUY", "kind":"signal", "metaStrings": {"risk.mode":"fixed_pct","risk.pct":"0.01"} }
+            ],
             "quota":{ "max": 100, "windowMs": 86400000 }
           },
           {
             "id":"short",
+            "event":{"type":"candle","symbol":"BTCUSDT"},
             "oncePerBar":true,
             "guard":{ "type":"crosses", "left":{"type":"series","name":"ema12"}, "dir":"BELOW", "right":{"type":"series","name":"ema26"} },
-            "action":{ "type":"EMIT", "symbol":"BTCUSDT", "side":"SELL", "kind":"signal"},
+            "actions":[
+              { "type":"emitOrder", "symbol":"BTCUSDT", "side":"SELL", "kind":"signal", "metaStrings": {"risk.mode":"fixed_pct","risk.pct":"0.01"} }
+            ],
             "quota":{ "max": 100, "windowMs": 86400000 }
           }
         ]

--- a/tools/src/test/kotlin/com/kevin/cryptotrader/tools/backtest/BuiltInStrategiesBacktestTest.kt
+++ b/tools/src/test/kotlin/com/kevin/cryptotrader/tools/backtest/BuiltInStrategiesBacktestTest.kt
@@ -1,0 +1,58 @@
+package com.kevin.cryptotrader.tools.backtest
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class BuiltInStrategiesBacktestTest {
+  private fun loadStrategy(name: String): String {
+    val path = resolvePath("fixtures/strategies/$name.json")
+    return Files.readString(path)
+  }
+
+  private fun resolvePath(path: String) = listOf(
+    Paths.get(path),
+    Paths.get("../$path"),
+    Paths.get("../../$path"),
+    Paths.get("../../../$path"),
+  ).firstOrNull { Files.exists(it) } ?: error("Fixture not found: $path")
+
+  private fun runStrategy(name: String): BacktestMetrics {
+    val programJson = loadStrategy(name)
+    val bt = Backtester(
+      BacktestConfig(
+        programJson = programJson,
+        priority = listOf("strategy.", "automation."),
+      ),
+    )
+    return bt.run()
+  }
+
+  @Test
+  fun built_in_strategies_have_deterministic_metrics() {
+    val expected = mapOf(
+      "ema" to BacktestMetrics(bars = 200, intents = 4, orders = 0, fills = 0),
+      "rsi" to BacktestMetrics(bars = 200, intents = 6, orders = 0, fills = 0),
+      "bollinger" to BacktestMetrics(bars = 200, intents = 22, orders = 0, fills = 0),
+      "macd" to BacktestMetrics(bars = 200, intents = 7, orders = 0, fills = 0),
+      "donchian" to BacktestMetrics(bars = 200, intents = 0, orders = 0, fills = 0),
+      "rotation" to BacktestMetrics(bars = 200, intents = 24, orders = 0, fills = 0),
+      "zscore" to BacktestMetrics(bars = 200, intents = 11, orders = 0, fills = 0),
+      "grid" to BacktestMetrics(bars = 200, intents = 99, orders = 0, fills = 0),
+      "dca" to BacktestMetrics(bars = 200, intents = 4, orders = 1, fills = 0),
+      "pair_ratio" to BacktestMetrics(bars = 200, intents = 0, orders = 0, fills = 0),
+    )
+
+    val actual = expected.keys.associateWith { name -> runStrategy(name) }
+    actual.forEach { (name, metrics) ->
+      println("strategy=$name metrics=$metrics")
+    }
+    expected.forEach { (name, expectedMetrics) ->
+      val metrics = actual.getValue(name)
+      assertEquals(expectedMetrics.bars, metrics.bars, "$name bars")
+      assertEquals(expectedMetrics.intents, metrics.intents, "$name intents")
+      assertEquals(expectedMetrics.orders, metrics.orders, "$name orders")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend the runtime bytecode schema and interpreter to cover the expanded block operations, additional indicators, and new automation actions
- enhance the backtester and compiler to load the richer program schema and multi-symbol data sources
- add JSON fixtures for the ten built-in strategies and a deterministic regression test to lock in their backtest metrics

## Testing
- ./gradlew :tools:test --tests "com.kevin.cryptotrader.tools.backtest.BuiltInStrategiesBacktestTest"


------
https://chatgpt.com/codex/tasks/task_e_68e387b46e10832195a995e4f8150f8a