### PR TITLE
Implement secure storage and compliance safeguards

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,4 +53,7 @@ android {
         implementation 'androidx.navigation:navigation-compose:2.8.0'
         implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0'
         implementation 'androidx.compose.material:material-icons-extended:1.6.7'
+        implementation 'androidx.preference:preference-ktx:1.2.1'
+        implementation 'androidx.security:security-crypto:1.1.0-alpha06'
+        implementation 'androidx.biometric:biometric:1.1.0'
     }

--- a/app/src/main/java/com/example/myandroidapp/MainActivity.kt
+++ b/app/src/main/java/com/example/myandroidapp/MainActivity.kt
@@ -3,16 +3,37 @@ package com.example.myandroidapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.example.myandroidapp.screens.ComplianceOnboardingDialog
 import com.example.myandroidapp.screens.RootNavigation
+import com.example.myandroidapp.security.SecurePreferencesManager
 import com.example.myandroidapp.theme.CryptoTraderTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val securePreferencesManager = SecurePreferencesManager.getInstance(applicationContext)
+        val shouldShowOnboarding = !securePreferencesManager.getBoolean(PREF_ONBOARDING_COMPLETE, false)
+
         setContent {
             CryptoTraderTheme {
-                RootNavigation()
+                val showOnboarding = remember { mutableStateOf(shouldShowOnboarding) }
+                Box {
+                    RootNavigation(securePreferencesManager)
+                    if (showOnboarding.value) {
+                        ComplianceOnboardingDialog(onAcknowledge = {
+                            securePreferencesManager.putBoolean(PREF_ONBOARDING_COMPLETE, true)
+                            showOnboarding.value = false
+                        })
+                    }
+                }
             }
         }
+    }
+
+    companion object {
+        private const val PREF_ONBOARDING_COMPLETE = "onboarding_complete"
     }
 }

--- a/app/src/main/java/com/example/myandroidapp/screens/ComplianceOnboardingDialog.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/ComplianceOnboardingDialog.kt
@@ -1,0 +1,36 @@
+package com.example.myandroidapp.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ComplianceOnboardingDialog(onAcknowledge: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = {},
+        confirmButton = {
+            Button(onClick = onAcknowledge) {
+                Text("I understand")
+            }
+        },
+        title = { Text("Before you continue", style = MaterialTheme.typography.titleLarge) },
+        text = {
+            Column {
+                Text("CryptoTrader automates trading workflows but does not provide financial or investment advice.")
+                Spacer(Modifier.height(8.dp))
+                Text("Exchange API credentials are encrypted using the Android Keystore and never transmitted without your consent. Keep read-only permissions where possible and revoke keys you no longer use.")
+                Spacer(Modifier.height(8.dp))
+                Text("Trading history, automation rules, and logs remain on your device. Clearing app data or uninstalling the application removes this information.")
+                Spacer(Modifier.height(8.dp))
+                Text("By continuing you acknowledge responsibility for complying with exchange terms, regional regulations, and safeguarding your credentials.")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/myandroidapp/screens/RootNavigation.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/RootNavigation.kt
@@ -2,6 +2,7 @@ package com.example.myandroidapp.screens
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Home
@@ -14,35 +15,73 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.*
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 import com.example.myandroidapp.shared.SharedAppViewModel
+import com.example.myandroidapp.security.SecurePreferencesManager
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RootNavigation() {
+fun RootNavigation(securePreferencesManager: SecurePreferencesManager) {
     val navController = rememberNavController()
     val viewModel: SharedAppViewModel = viewModel()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    val title = when (currentRoute) {
+        "home" -> "Home"
+        "markets" -> "Markets"
+        "tools" -> "Tools"
+        "settings" -> "Settings"
+        else -> "CryptoTrader"
+    }
 
     Scaffold(
         topBar = {
             SmallTopAppBar(
-                title = {},
-                actions = {
-                    IconButton(onClick = { /* TODO: profile */ }) {
-                        Icon(Icons.Default.Person, contentDescription = "Profile")
+                title = { Text(title) },
+                navigationIcon = if (currentRoute == "settings") {
+                    {
+                        IconButton(onClick = { navController.popBackStack() }) {
+                            Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        }
                     }
-                    IconButton(onClick = { /* TODO: settings */ }) {
-                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                } else null,
+                actions = {
+                    if (currentRoute != "settings") {
+                        IconButton(onClick = { /* TODO: profile */ }) {
+                            Icon(Icons.Default.Person, contentDescription = "Profile")
+                        }
+                        IconButton(onClick = {
+                            navController.navigate("settings") {
+                                launchSingleTop = true
+                            }
+                        }) {
+                            Icon(Icons.Default.Settings, contentDescription = "Settings")
+                        }
                     }
                 }
             )
         },
-        bottomBar = { RootBottomNavBar(navController) }
+        bottomBar = {
+            if (currentRoute != "settings") {
+                RootBottomNavBar(navController)
+            }
+        }
     ) { padding ->
-        NavHost(navController = navController, startDestination = "home", modifier = Modifier.padding(padding)) {
+        NavHost(
+            navController = navController,
+            startDestination = "home",
+            modifier = Modifier.padding(padding)
+        ) {
             composable("home") { HomeSection(viewModel) }
             composable("markets") { MarketSection(viewModel) }
             composable("tools") { ToolsSection(viewModel) }
+            composable("settings") {
+                SettingsScreen(onNavigateBack = { navController.popBackStack() })
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/myandroidapp/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/myandroidapp/screens/SettingsScreen.kt
@@ -1,0 +1,204 @@
+package com.example.myandroidapp.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import com.example.myandroidapp.security.BiometricAuthenticator
+import com.example.myandroidapp.security.ExchangeKeyRepository
+import com.example.myandroidapp.security.SecurePreferencesManager
+
+@Composable
+fun SettingsScreen(onNavigateBack: () -> Unit) {
+    val context = LocalContext.current
+    val fragmentActivity = remember(context) {
+        requireNotNull(context as? FragmentActivity) {
+            "SettingsScreen requires to be hosted in a FragmentActivity context"
+        }
+    }
+    val authenticator = remember(fragmentActivity) { BiometricAuthenticator(fragmentActivity) }
+    val repository = remember(context) { ExchangeKeyRepository.getInstance(context) }
+    // Ensure encrypted preferences are eagerly initialised so migration from legacy storage
+    // happens even if the user navigates directly to settings.
+    remember(context) { SecurePreferencesManager.getInstance(context) }
+
+    var exchangeId by rememberSaveable { mutableStateOf("") }
+    var apiKey by rememberSaveable { mutableStateOf("") }
+    var apiSecret by rememberSaveable { mutableStateOf("") }
+    var statusMessage by rememberSaveable { mutableStateOf<String?>(null) }
+    var storedExchanges by remember { mutableStateOf(repository.getStoredExchanges().sorted()) }
+    var revealedExchange by remember { mutableStateOf<String?>(null) }
+    var revealedKeys by remember { mutableStateOf<ExchangeKeyRepository.ExchangeKeys?>(null) }
+
+    // Refresh stored exchanges whenever the repository content changes externally.
+    LaunchedEffect(Unit) {
+        storedExchanges = repository.getStoredExchanges().sorted()
+    }
+
+    Column(
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Compliance & Disclaimers",
+            style = MaterialTheme.typography.titleLarge
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("\u2022 CryptoTrader provides tooling for account management and automation only; it does not deliver investment or trading advice.")
+            Text("\u2022 API keys remain encrypted on-device using the Android Keystore. Keys are never transmitted to external services without your explicit action.")
+            Text("\u2022 You are responsible for configuring exchange permissions and revoking credentials if your device is lost or compromised.")
+        }
+
+        Text(
+            text = "Data Retention",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("\u2022 Trading history, automation rules, and ledger snapshots are stored locally within the app's encrypted databases.")
+            Text("\u2022 You can clear stored exchange credentials per exchange using the controls below; this immediately removes keys from encrypted storage.")
+            Text("\u2022 Diagnostic analytics are not collected. Logs remain on-device and are cleared when you uninstall the application.")
+        }
+
+        Divider()
+
+        Text(
+            text = "Secure Exchange Keys",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedTextField(
+                value = exchangeId,
+                onValueChange = { exchangeId = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Exchange identifier") },
+                singleLine = true
+            )
+            OutlinedTextField(
+                value = apiKey,
+                onValueChange = { apiKey = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("API key") },
+                singleLine = true
+            )
+            OutlinedTextField(
+                value = apiSecret,
+                onValueChange = { apiSecret = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("API secret") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation()
+            )
+            Button(
+                onClick = {
+                    runCatching {
+                        repository.saveExchangeKeys(exchangeId, apiKey, apiSecret)
+                    }.onSuccess {
+                        statusMessage = "Credentials saved for ${exchangeId.trim()}"
+                        storedExchanges = repository.getStoredExchanges().sorted()
+                        revealedExchange = null
+                        revealedKeys = null
+                        exchangeId = ""
+                        apiKey = ""
+                        apiSecret = ""
+                    }.onFailure {
+                        statusMessage = it.message ?: "Unable to store credentials"
+                    }
+                },
+                enabled = exchangeId.isNotBlank() && apiKey.isNotBlank() && apiSecret.isNotBlank(),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Store securely")
+            }
+        }
+
+        if (storedExchanges.isNotEmpty()) {
+            Divider()
+            Text(
+                text = "Stored exchanges",
+                style = MaterialTheme.typography.titleMedium
+            )
+            storedExchanges.forEach { storedExchange ->
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(storedExchange, style = MaterialTheme.typography.bodyLarge)
+                    if (revealedExchange == storedExchange && revealedKeys != null) {
+                        Text("API key: ${revealedKeys!!.apiKey}")
+                        Text("API secret: ${revealedKeys!!.apiSecret}")
+                    } else {
+                        Text("Credentials protected. Authenticate to reveal.")
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = {
+                            authenticator.authenticate(
+                                title = "Authenticate to reveal keys",
+                                subtitle = storedExchange,
+                                description = "Biometric authentication is required before viewing API credentials.",
+                                onSuccess = {
+                                    val keys = repository.getExchangeKeys(storedExchange)
+                                    if (keys != null) {
+                                        revealedExchange = storedExchange
+                                        revealedKeys = keys
+                                        statusMessage = null
+                                    } else {
+                                        statusMessage = "No credentials found for $storedExchange"
+                                    }
+                                },
+                                onError = { error ->
+                                    statusMessage = error
+                                }
+                            )
+                        }) {
+                            Text("Reveal")
+                        }
+                        OutlinedButton(onClick = {
+                            repository.clearExchangeKeys(storedExchange)
+                            storedExchanges = repository.getStoredExchanges().sorted()
+                            if (revealedExchange == storedExchange) {
+                                revealedExchange = null
+                                revealedKeys = null
+                            }
+                            statusMessage = "Removed credentials for $storedExchange"
+                        }) {
+                            Text("Remove")
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+
+        statusMessage?.let {
+            Text(it, color = MaterialTheme.colorScheme.primary)
+        }
+
+        Divider()
+        TextButton(onClick = onNavigateBack, modifier = Modifier.fillMaxWidth()) {
+            Text("Close settings")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myandroidapp/security/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/example/myandroidapp/security/BiometricAuthenticator.kt
@@ -1,0 +1,63 @@
+package com.example.myandroidapp.security
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+/**
+ * Helper responsible for gating access to sensitive data behind a biometric prompt.
+ */
+class BiometricAuthenticator(private val activity: FragmentActivity) {
+
+    private val executor = ContextCompat.getMainExecutor(activity)
+
+    fun canAuthenticate(): Boolean {
+        val biometricManager = BiometricManager.from(activity)
+        val authenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG or
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        return biometricManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    fun authenticate(
+        title: String,
+        subtitle: String? = null,
+        description: String? = null,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit
+    ) {
+        if (!canAuthenticate()) {
+            onError("Biometric authentication is not available on this device.")
+            return
+        }
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setDescription(description)
+            .setAllowedAuthenticators(
+                BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                    BiometricManager.Authenticators.DEVICE_CREDENTIAL
+            )
+            .build()
+
+        val prompt = BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                super.onAuthenticationSucceeded(result)
+                onSuccess()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                super.onAuthenticationError(errorCode, errString)
+                onError(errString.toString())
+            }
+
+            override fun onAuthenticationFailed() {
+                super.onAuthenticationFailed()
+                onError("Biometric authentication failed. Please try again.")
+            }
+        })
+
+        prompt.authenticate(promptInfo)
+    }
+}

--- a/app/src/main/java/com/example/myandroidapp/security/ExchangeKeyRepository.kt
+++ b/app/src/main/java/com/example/myandroidapp/security/ExchangeKeyRepository.kt
@@ -1,0 +1,52 @@
+package com.example.myandroidapp.security
+
+import android.content.Context
+
+/**
+ * Repository responsible for persisting exchange API credentials inside encrypted storage.
+ */
+class ExchangeKeyRepository private constructor(
+    private val securePreferencesManager: SecurePreferencesManager
+) {
+
+    fun saveExchangeKeys(exchangeId: String, apiKey: String, apiSecret: String) {
+        val trimmedId = exchangeId.trim()
+        require(trimmedId.isNotEmpty()) { "Exchange identifier must not be blank." }
+
+        val existing = securePreferencesManager.getStringSet(EXCHANGES_KEY).toMutableSet()
+        existing.add(trimmedId)
+        securePreferencesManager.putStringSet(EXCHANGES_KEY, existing)
+        securePreferencesManager.putString(apiKeyKey(trimmedId), apiKey)
+        securePreferencesManager.putString(apiSecretKey(trimmedId), apiSecret)
+    }
+
+    fun getExchangeKeys(exchangeId: String): ExchangeKeys? {
+        val apiKey = securePreferencesManager.getString(apiKeyKey(exchangeId)) ?: return null
+        val apiSecret = securePreferencesManager.getString(apiSecretKey(exchangeId)) ?: return null
+        return ExchangeKeys(apiKey, apiSecret)
+    }
+
+    fun clearExchangeKeys(exchangeId: String) {
+        val exchanges = securePreferencesManager.getStringSet(EXCHANGES_KEY).toMutableSet()
+        exchanges.remove(exchangeId)
+        securePreferencesManager.putStringSet(EXCHANGES_KEY, exchanges)
+        securePreferencesManager.remove(apiKeyKey(exchangeId))
+        securePreferencesManager.remove(apiSecretKey(exchangeId))
+    }
+
+    fun getStoredExchanges(): Set<String> = securePreferencesManager.getStringSet(EXCHANGES_KEY)
+
+    data class ExchangeKeys(val apiKey: String, val apiSecret: String)
+
+    companion object {
+        private const val EXCHANGES_KEY = "stored_exchanges"
+
+        fun getInstance(context: Context): ExchangeKeyRepository {
+            val securePrefs = SecurePreferencesManager.getInstance(context)
+            return ExchangeKeyRepository(securePrefs)
+        }
+
+        private fun apiKeyKey(exchangeId: String) = "${exchangeId}_api_key"
+        private fun apiSecretKey(exchangeId: String) = "${exchangeId}_api_secret"
+    }
+}

--- a/app/src/main/java/com/example/myandroidapp/security/SecurePreferencesManager.kt
+++ b/app/src/main/java/com/example/myandroidapp/security/SecurePreferencesManager.kt
@@ -1,0 +1,111 @@
+package com.example.myandroidapp.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Centralised access point for encrypted shared preferences backed by the Android Keystore.
+ *
+ * A one-time migration copies all entries from the legacy shared preferences into the
+ * encrypted storage to guarantee that previously persisted values remain available after the
+ * upgrade.
+ */
+class SecurePreferencesManager private constructor(appContext: Context) {
+
+    private val masterKey: MasterKey = MasterKey.Builder(appContext)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val encryptedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
+        appContext,
+        SECURE_PREF_FILE,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    private val legacyPreferences: SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(appContext)
+
+    init {
+        migrateLegacyPreferencesIfNeeded()
+    }
+
+    private fun migrateLegacyPreferencesIfNeeded() {
+        if (encryptedPreferences.getBoolean(MIGRATION_COMPLETED_KEY, false)) {
+            return
+        }
+
+        val legacyEntries = legacyPreferences.all
+        if (legacyEntries.isEmpty()) {
+            encryptedPreferences.edit().putBoolean(MIGRATION_COMPLETED_KEY, true).apply()
+            return
+        }
+
+        val secureEditor = encryptedPreferences.edit()
+        legacyEntries.forEach { (key, value) ->
+            when (value) {
+                is String -> secureEditor.putString(key, value)
+                is Int -> secureEditor.putInt(key, value)
+                is Boolean -> secureEditor.putBoolean(key, value)
+                is Float -> secureEditor.putFloat(key, value)
+                is Long -> secureEditor.putLong(key, value)
+                is Set<*> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    val castValue = value as? Set<String>
+                    if (castValue != null) {
+                        secureEditor.putStringSet(key, castValue)
+                    }
+                }
+            }
+        }
+        secureEditor.putBoolean(MIGRATION_COMPLETED_KEY, true)
+        secureEditor.apply()
+
+        // Wipe the legacy preferences once migration has succeeded.
+        legacyPreferences.edit().clear().apply()
+    }
+
+    fun putString(key: String, value: String) {
+        encryptedPreferences.edit().putString(key, value).apply()
+    }
+
+    fun getString(key: String): String? = encryptedPreferences.getString(key, null)
+
+    fun putBoolean(key: String, value: Boolean) {
+        encryptedPreferences.edit().putBoolean(key, value).apply()
+    }
+
+    fun getBoolean(key: String, defaultValue: Boolean = false): Boolean =
+        encryptedPreferences.getBoolean(key, defaultValue)
+
+    fun putStringSet(key: String, values: Set<String>) {
+        encryptedPreferences.edit().putStringSet(key, values).apply()
+    }
+
+    fun getStringSet(key: String, defaultValue: Set<String> = emptySet()): Set<String> =
+        encryptedPreferences.getStringSet(key, defaultValue) ?: defaultValue
+
+    fun remove(key: String) {
+        encryptedPreferences.edit().remove(key).apply()
+    }
+
+    companion object {
+        private const val SECURE_PREF_FILE = "secure_prefs"
+        private const val MIGRATION_COMPLETED_KEY = "secure_prefs_migrated"
+
+        @Volatile
+        private var instance: SecurePreferencesManager? = null
+
+        fun getInstance(context: Context): SecurePreferencesManager {
+            return instance ?: synchronized(this) {
+                instance ?: SecurePreferencesManager(context.applicationContext).also {
+                    instance = it
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- secure existing preferences by migrating into Android Keystore backed encrypted storage and expose a repository for managing exchange credentials
- gate access to stored exchange API keys behind BiometricPrompt and add a settings surface for managing keys with compliance disclaimers and retention notices
- introduce an onboarding compliance dialog and navigation updates so the new safeguards are shown on first launch and via the settings icon

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e485aaab88832191e5325dcf870334